### PR TITLE
Add Learn Rust Resources

### DIFF
--- a/docs/contributing/guides/stacks/_category_.json
+++ b/docs/contributing/guides/stacks/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Learn Our Stacks",
+    "position": 4
+  }
+  

--- a/docs/contributing/guides/stacks/_category_.json
+++ b/docs/contributing/guides/stacks/_category_.json
@@ -1,5 +1,5 @@
 {
-    "label": "Learn Our Stacks",
+    "label": "Project Stacks",
     "position": 4
   }
   

--- a/docs/contributing/guides/stacks/crash-course/_category_.json
+++ b/docs/contributing/guides/stacks/crash-course/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Crash Courses",
+    "position": 1
+  }
+  

--- a/docs/contributing/guides/stacks/crash-course/rust-crash-course.md
+++ b/docs/contributing/guides/stacks/crash-course/rust-crash-course.md
@@ -1,0 +1,357 @@
+# Arrow Rust Crash Course
+
+Through these projects you will learn what you need to contribute to the Arrow Rust codebase.
+
+Attempt these steps without looking them up first! You'll only learn by trying them yourself.
+
+You're meant to struggle a bit - don't worry! The compiler will help :)
+
+When you're ready for help, many of the instructions link to helpful resources or Rust docs.
+
+## Level 0 - Libraries, Tests, Refs
+
+1) Compile the [Hello, Cargo!](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html) project
+
+2) [Create src/lib.rs and add it as a library to Cargo.toml](https://doc.rust-lang.org/cargo/reference/cargo-targets.html?highlight=library#configuring-a-target)
+
+<details><summary>Solution</summary>
+<p>
+
+```toml
+# in Cargo.toml
+[lib]
+name = "adder"
+path = "src/lib.rs"
+test = true
+```
+</p>
+</details>
+
+3) Add a function to `src/lib.rs` which takes an unsigned integer as an argument and [returns](https://doc.rust-lang.org/rust-by-example/fn.html) the sum.
+
+```rust
+fn add_one(x: u32) -> u32 {
+    // what are two ways to return a value from this function?
+    // ...
+}
+```
+
+4) Add a [unit test](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html) to the bottom of `lib.rs` for `add_one`
+- Unit tests validate the internal workings of a module
+- Use [`assert_eq!`](https://doc.rust-lang.org/std/macro.assert_eq.html) to compare the result with the expected result
+
+<details><summary>Solution</summary>
+<p>
+
+```rust
+// Bottom of lib.rs
+#[cfg(test)]
+mod tests {
+    // `mod tests` is its own context, so functions must be
+    //   imported from the library even though the tests are
+    //   in the same file
+    
+    // Imports all functions from file, specifically `add_one`
+    use super::*;
+
+    #[test]
+    fn ut_add_one() {
+        let x: u32 = 5;
+        let result = add_one(x);
+        assert_eq!(x + 1, result); 
+    }
+}
+```
+</p>
+</details>
+
+5) Add an [integration test](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html) for `add_one`
+- This should go into a new file: `tests/integration_test.rs`
+
+<details><summary>Solution</summary>
+<p>
+
+```rust
+// Top of tests/integration_test.rs
+#[test]
+fn it_add_one() {
+    let x: u32 = 5;
+
+    // No imports needed, all public functions
+    //  from all libraries are accessible by
+    //  integration tests
+    assert_eq!(adder::add_one(x), x+1);
+}
+```
+</p>
+</details>
+
+- You may get the following compilation error:
+
+```rust
+error[E0603]: function `add_one` is private
+ --> tests/integration_test.rs:4:23
+  |
+4 |     assert_eq!(adder::add_one(x), x+1);
+  |                       ^^^^^^^ private function
+```
+
+- To test this function in `integration_test.rs`, we need to make `add_one` public.
+  - `pub fn add_one(x: u32) -> u32`
+- This emphasizes what integration tests are for!
+  - Integration tests should validate the *public* interfaces (inputs and outputs) of a module
+  - These tests provide confidence that *other* modules can interact with this module's public interfaces without causing an error
+  - By proving this, we verify module *integration*, the interoperation of multiple modules as a successful whole
+
+6) Modify `add_one` to instead update `x` in place, with no return value.
+- You'll learn more about `mut`, references, and `&mut`!
+- Hint: https://www.educative.io/answers/how-to-use-references-in-rust
+
+<details><summary>Solution</summary>
+<p>
+
+```rust
+// in src/lib.rs
+// Pass a mutable/editable reference to the variable: &mut 
+pub fn add_one(x: &mut u32) {
+    // Since X is now a pointer (&), must dereference with *
+    *x += 1
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn ut_add_one() {
+        let mut x: u32 = 5;
+        let orig = x;
+
+        // Error if we try add_one(x)
+        // Add one only accepts a mutable pointer
+        // with &mut we pass the pointer to x to the function
+        add_one(&mut x); // no return value!
+        assert_eq!(orig + 1, x); 
+    }
+}
+```
+```rust
+// in tests/integration_test.rs
+#[test]
+fn it_add_one() {
+    let start: u32 = 5;
+    let mut x: u32 = start;
+    adder::add_one(&mut x);
+    assert_eq!(x, start + 1);
+}
+
+```
+</p>
+</details>
+
+## Level 1 - Generics, Traits, Imports
+
+1) Write a function which returns the largest element of a [vector](https://doc.rust-lang.org/std/vec/struct.Vec.html) of type `u32`
+- `fn largest(xs: &[u32]) -> u32`
+- Why should `largest` take a pointer to the list (`&[u32]`) instead of the list (`[u32]`)?
+    - Consider the size of a pointer versus the size of the list
+- Why not a mutable pointer `&mut`?
+
+<details><summary>Solution</summary>
+<p>
+
+```rust
+// There are several implementations possible
+// largest takes a pointer to the vector instead of copying the
+//   the whole vector. A pointer is 4 bytes. The vector might
+//   be hundreds of bytes
+// The pointer is not mutable (&mut[u32]) because we do not want
+//   the list to be modified. We only want to find the largest
+//   element.
+// This is a powerful protection, similar to const arguments in
+//   C/C++, but by default.
+fn largest(list: &[u32]) -> u32 {
+    let mut largest: u32 = list[0];
+
+    // &item means a reference to (and not a copy of) item
+    for &item in list {
+        if item > largest {
+            largest = item;
+        }
+    }
+
+    largest
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    fn ut_largest() {
+        let max = 100;
+        let xs = vec![max - 1, max - 10, max - 50];
+        assert_eq!(max, largest(&xs));
+    }
+}
+```
+</p>
+</details>
+
+2) [Modify `largest` to return the largest element of a vector of *any type*](https://doc.rust-lang.org/book/ch10-01-syntax.html)
+- This one is tricky!
+- You'll learn about Generics and `trait`s, specifically `PartialOrd` and `Copy`
+
+<details><summary>Solution</summary>
+<p>
+
+```rust
+// How to read:
+// return the largest item from list of items of type T
+//   where T must be Orderable/Sortable and Copyable
+fn largest<T: PartialOrd + Copy>(list: &[T]) -> T {
+    // Makes a copy of an element of type T
+    //  therefore T must be Copyable
+    let mut largest: T = list[0];
+
+    for &item in list {
+        // Compares items of type T
+        // Greater than (>) operator requires two objects
+        //  that can be compared
+        // Therefore PartialOrd trait
+        if item > largest {
+            largest = item;
+        }
+    }
+
+    largest
+}
+```
+</p>
+</details>
+
+- Run the same unit tests again, should pass!
+- Try changing the unit tests to add together other types: f32, u8, i16, etc.
+
+
+3) Add a [data structure](https://doc.rust-lang.org/rust-by-example/custom_types/structs.html) called `Ticket`.
+- `Ticket` shouldhave  two fields:
+    - `u32 id`
+    - `DateTime<UTC> timestamp`
+- We need to import an external crate: `chrono`
+    - [Add `chrono` to your `cargo.toml` under `[dependencies]`](https://crates.io/crates/chrono) (see "Usage")
+        - Alternatively run `cargo add chrono` from your project root
+    - [Importing DateTime and Utc to your file](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#example) 
+
+<details><summary>Solution</summary>
+<p>
+
+```rust
+use chrono::{DateTime, Utc};
+
+struct Ticket {
+    id: u32,
+    timestamp: DateTime<Utc>
+}
+```
+
+</p>
+</details>
+
+4) Create a unit test `ut_largest_ticket` which does the following:
+- Creates a vector `tickets` with the following two `Ticket` elements:
+    - `Ticket { id: 1, timestamp: Utc::now() }`
+    - `Ticket { id: 2, timestamp: Utc::now() + Duration::minutes(30) }`
+- Passes this `Ticket` vector to the `largest` function.
+- [assert_eq!](https://doc.rust-lang.org/std/macro.assert.html#examples) that the ID of the returned element is `2`.
+
+<details><summary>Solution</summary>
+<p>
+
+```rust
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    // Duration is used in unit tests, but not in library
+    // import here
+    use chrono::{Duration};
+
+    #[test]
+    fn ut_largest() {
+        let tickets = vec![
+            Ticket { id: 1, timestamp: Utc::now() },
+            Ticket { id: 2, timestamp: Utc::now() + Duration::minutes(30) }
+        ];
+        assert_eq!(2, largest(&tickets).id);
+    }
+}
+```
+</p>
+</details>
+
+- *Should fail to compile!*
+
+5) The compiler doesn't know how to compare two `Ticket` objects yet.
+- Add `#[derive(Debug, Eq, Copy, Clone)]` above `Ticket`
+  - [This tells Rust to provide code for copying, checking for equality, and printing this object to standard output.](https://doc.rust-lang.org/rust-by-example/trait/derive.html)
+
+<details><summary>Solution</summary>
+<p>
+
+```rust
+#[derive(Debug, Eq, Copy, Clone)]
+struct Ticket {
+    id: u32,
+    timestamp: DateTime<Utc>
+}
+```
+
+</p></details>
+
+6) The compiler needs to be told how to determine if one `Ticket` is "larger" than another.
+- We'll say that the "largest" ticket should be the one with the **later** timestamp.
+- [Implement the `PartialOrd`, `Ord`, and `PartialEq` traits for the `Ticket` object.](https://doc.rust-lang.org/std/cmp/trait.Ord.html#how-can-i-implement-ord)
+- [Traits define behaviors for types](https://doc.rust-lang.org/book/ch10-02-traits.html).
+
+<details><summary>Solution</summary>
+<p>
+
+```rust
+use std::cmp::Ordering;
+
+#[derive(Debug, Eq, Copy, Clone)]
+struct Ticket {
+    id: u32,
+    timestamp: DateTime<Utc>
+}
+
+impl Ord for Ticket {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.timestamp.cmp(&other.timestamp)
+    }
+}
+
+impl PartialOrd for Ticket {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Ticket {
+    fn eq(&self, other: &Self) -> bool {
+        self.timestamp == other.timestamp
+    }
+}
+```
+</p>
+</details>
+
+7) Run the unit tests again.
+- Should pass!
+
+## Level 2
+
+- Coming Soon
+- `Option`, `trait`, `enum`

--- a/docs/contributing/guides/stacks/crash-course/rust-crash-course.md
+++ b/docs/contributing/guides/stacks/crash-course/rust-crash-course.md
@@ -36,6 +36,38 @@ fn add_one(x: u32) -> u32 {
 }
 ```
 
+<details><summary>Solution</summary>
+<p>
+
+```rust
+fn add_one(x: u32) -> u32 {
+    x + 1
+    
+    // Could also return with:
+    // return x + 1; 
+}
+```
+    
+Notice that there is no semicolon `;` after `x+1`. `return` is not needed when the returned value is the last expression in the function.
+
+Try adding a semicolon and see the compiler explanation!
+    
+```bash
+$ cargo build
+error[E0308]: mismatched types
+ --> src/main.rs:1:23
+  |
+1 | fn add_one(x: u32) -> u32 {
+  |    -------            ^^^ expected `u32`, found `()`
+  |    |
+  |    implicitly returns `()` as its body has no tail or `return` expression
+2 |     x + 1;
+  |          - help: remove this semicolon
+```
+    
+</p>
+</details>
+
 4) Add a [unit test](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html) to the bottom of `lib.rs` for `add_one`
 - Unit tests validate the internal workings of a module
 - Use [`assert_eq!`](https://doc.rust-lang.org/std/macro.assert_eq.html) to compare the result with the expected result

--- a/docs/contributing/guides/stacks/intro.md
+++ b/docs/contributing/guides/stacks/intro.md
@@ -1,5 +1,0 @@
-# Learn Our Stacks
-
-Projects:
-- [Services Stack](./services-stack.md)
-- [Spearhead Stack](./spearhead-stack.md)

--- a/docs/contributing/guides/stacks/intro.md
+++ b/docs/contributing/guides/stacks/intro.md
@@ -1,0 +1,5 @@
+# Learn Our Stacks
+
+Projects:
+- [Services Stack](./services-stack.md)
+- [Spearhead Stack](./spearhead-stack.md)

--- a/docs/contributing/guides/stacks/services-stack.md
+++ b/docs/contributing/guides/stacks/services-stack.md
@@ -15,70 +15,8 @@ See our [Stack Comparison](https://docs.google.com/spreadsheets/d/1pHNHEm26fOMxo
   - Error messages are clear and thorough
   - Often suggests code corrections, even directs you to code examples!
 
-#### Crash Course
-
-These are projects to get a basic grasp of Rust. You're meant to struggle a bit - don't worry! The compiler will help :)
-
-Level 0:
-1) Compile the [Hello, Cargo!](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html) project
-2) [Add a src/lib.rs file and add the library to the cargo.toml](https://doc.rust-lang.org/cargo/reference/cargo-targets.html?highlight=library#library)
-3) Add a function to `lib.rs` which takes an unsigned integer as an argument and returns the sum.
-    - `pub fn add_one(a: u32) -> u32`
-4) Add a [unit test](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html) for `add_one`
-    - Use [`assert_eq!`](https://doc.rust-lang.org/std/macro.assert_eq.html) to compare the result with the expected result
-    ```rust
-    let x: u32 = 5;
-    let result = add_one(x);
-    assert_eq!(result, 6)
-    ```
-    - Unit tests validate the internal workings of a module
-5) Add an [integration test](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html) to `tests/integration_test.rs` which also tests `add_one`
-    - This is simply to show the difference in compiling unit and integration tests
-    - Integration tests target the interfaces of a module
-6) Modify `add_one` to instead update `a` in place, with no return value.
-    ```rust
-    let mut x: u32 = 5;
-    add_one(x); // no return value!
-    assert_eq!(x, 6)
-    ```
-    - Hint: https://www.educative.io/answers/how-to-use-references-in-rust
-
-Level 1:
-1) Create a single function which returns the largest element of a [vector](https://doc.rust-lang.org/std/vec/struct.Vec.html) of type `u32`
-    - `fn largest(xs: &[u32]) -> u32`
-    - Why should `largest` take a pointer to the list (`&[u32]`) instead of the list (`[u32]`)?
-        - Consider the size of a pointer versus the size of the list
-        - `&[T]` is also called a `slice`
-            - Good [StackOverflow explanation](https://stackoverflow.com/questions/61151041/what-is-the-difference-between-a-slice-and-reference-in-rust)
-2) Modify the function to return the largest element of a [vector of *any type*](https://doc.rust-lang.org/book/ch10-01-syntax.html)
-    - `fn largest<T>(xs: &[T]) -> T`
-3) Add a [data structure](https://doc.rust-lang.org/rust-by-example/custom_types/structs.html) called `Ticket`.
-    - `Ticket` shouldhave  two fields:
-        - `u32 id`
-        - `DateTime<UTC> timestamp`
-    - We need to import an external crate: `chrono`
-        - [Add `chrono` to your `cargo.toml` under `[dependencies]`](https://crates.io/crates/chrono) (see "Usage")
-        - [Importing DateTime and UTC to your file](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#example) 
-4) Create a unit test `ut_largest_ticket` which does the following:
-    - Creates a vector `tickets` with the following two `Ticket` elements:
-        - `Ticket { id: 1, timestamp: Utc::now() }`
-        - `Ticket { id: 2, timestamp: Utc::now() + Duration::minutes(30) }`
-    - Pass this `Ticket` vector to the `largest` function.
-    - [Assert](https://doc.rust-lang.org/std/macro.assert.html#examples) that the ID of the returned element is `2`. 
-    - Should fail to compile!
-5) The compiler doesn't know how to compare two `Ticket` objects - yet.
-    - [Implement the `PartialOrd`, `Ord`, and `PartialEq` traits for the `Ticket` object.](https://doc.rust-lang.org/std/cmp/trait.Ord.html#how-can-i-implement-ord)
-    - We'll say that the "largest" ticket should be the one with the later timestamp.
-    - Since we've implemented `PartialEq`, we can let the Rust compiler implement `Eq` for us.
-        - Add `#derive[(Eq)]` above `Ticket` to tell Rust to implement this trait for us.
-    - [Traits define behaviors for types](https://doc.rust-lang.org/book/ch10-02-traits.html).
-6) Run the unit tests again.
-    - Should pass!
-
-Level 2:
-- Coming Soon
-
 #### Learning Resources
+- [Arrow Rust Crash Course](./crash-course/rust-crash-course.md)
 - [Rust in Action](https://livebook.manning.com/book/rust-in-action/welcome/v-11/) - Tim McNamara
     - First few chapters are free to read online
 
@@ -133,3 +71,5 @@ We're using the following framework(s) on a trial basis:
 ### :brain: ML & Deep Learning Frameworks
 - Simulation
 - Optimization
+
+

--- a/docs/contributing/guides/stacks/services-stack.md
+++ b/docs/contributing/guides/stacks/services-stack.md
@@ -1,0 +1,135 @@
+# Software Services Stack
+
+:construction: In Progress! :construction:
+
+See our [Stack Comparison](https://docs.google.com/spreadsheets/d/1pHNHEm26fOMxoBKIYfFaa7wGh-M9Thxa8qddLBMz4Xw/edit#gid=2034044715) document for rationale on our selections.
+
+## :heavy_check_mark: Confirmed
+
+### :black_nib: Backend Language - *Rust*
+
+#### Overview
+
+- [Rust](https://www.rust-lang.org/) is a systems programming language which emphasizes memory safety, performance, and productivity.
+- Rust's helpful (and extremely picky) compiler is a fantastic teacher
+  - Error messages are clear and thorough
+  - Often suggests code corrections, even directs you to code examples!
+
+#### Crash Course
+
+These are projects to get a basic grasp of Rust. You're meant to struggle a bit - don't worry! The compiler will help :)
+
+Level 0:
+1) Compile the [Hello, Cargo!](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html) project
+2) [Add a src/lib.rs file and add the library to the cargo.toml](https://doc.rust-lang.org/cargo/reference/cargo-targets.html?highlight=library#library)
+3) Add a function to `lib.rs` which takes an unsigned integer as an argument and returns the sum.
+    - `pub fn add_one(a: u32) -> u32`
+4) Add a [unit test](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html) for `add_one`
+    - Use [`assert_eq!`](https://doc.rust-lang.org/std/macro.assert_eq.html) to compare the result with the expected result
+    ```rust
+    let x: u32 = 5;
+    let result = add_one(x);
+    assert_eq!(result, 6)
+    ```
+    - Unit tests validate the internal workings of a module
+5) Add an [integration test](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html) to `tests/integration_test.rs` which also tests `add_one`
+    - This is simply to show the difference in compiling unit and integration tests
+    - Integration tests target the interfaces of a module
+6) Modify `add_one` to instead update `a` in place, with no return value.
+    ```rust
+    let mut x: u32 = 5;
+    add_one(x); // no return value!
+    assert_eq!(x, 6)
+    ```
+    - Hint: https://www.educative.io/answers/how-to-use-references-in-rust
+
+Level 1:
+1) Create a single function which returns the largest element of a [vector](https://doc.rust-lang.org/std/vec/struct.Vec.html) of type `u32`
+    - `fn largest(xs: &[u32]) -> u32`
+    - Why should `largest` take a pointer to the list (`&[u32]`) instead of the list (`[u32]`)?
+        - Consider the size of a pointer versus the size of the list
+        - `&[T]` is also called a `slice`
+            - Good [StackOverflow explanation](https://stackoverflow.com/questions/61151041/what-is-the-difference-between-a-slice-and-reference-in-rust)
+2) Modify the function to return the largest element of a [vector of *any type*](https://doc.rust-lang.org/book/ch10-01-syntax.html)
+    - `fn largest<T>(xs: &[T]) -> T`
+3) Add a [data structure](https://doc.rust-lang.org/rust-by-example/custom_types/structs.html) called `Ticket`.
+    - `Ticket` shouldhave  two fields:
+        - `u32 id`
+        - `DateTime<UTC> timestamp`
+    - We need to import an external crate: `chrono`
+        - [Add `chrono` to your `cargo.toml` under `[dependencies]`](https://crates.io/crates/chrono) (see "Usage")
+        - [Importing DateTime and UTC to your file](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#example) 
+4) Create a unit test `ut_largest_ticket` which does the following:
+    - Creates a vector `tickets` with the following two `Ticket` elements:
+        - `Ticket { id: 1, timestamp: Utc::now() }`
+        - `Ticket { id: 2, timestamp: Utc::now() + Duration::minutes(30) }`
+    - Pass this `Ticket` vector to the `largest` function.
+    - [Assert](https://doc.rust-lang.org/std/macro.assert.html#examples) that the ID of the returned element is `2`. 
+    - Should fail to compile!
+5) The compiler doesn't know how to compare two `Ticket` objects - yet.
+    - [Implement the `PartialOrd`, `Ord`, and `PartialEq` traits for the `Ticket` object.](https://doc.rust-lang.org/std/cmp/trait.Ord.html#how-can-i-implement-ord)
+    - We'll say that the "largest" ticket should be the one with the later timestamp.
+    - Since we've implemented `PartialEq`, we can let the Rust compiler implement `Eq` for us.
+        - Add `#derive[(Eq)]` above `Ticket` to tell Rust to implement this trait for us.
+    - [Traits define behaviors for types](https://doc.rust-lang.org/book/ch10-02-traits.html).
+6) Run the unit tests again.
+    - Should pass!
+
+Level 2:
+- Coming Soon
+
+#### Learning Resources
+- [Rust in Action](https://livebook.manning.com/book/rust-in-action/welcome/v-11/) - Tim McNamara
+    - First few chapters are free to read online
+
+### :scroll: Scripting & Tools - *Python 3*
+
+For short scripts and tools to aid development.
+- Autocoding
+- Integration Tests
+
+## :exclamation: Nearing Decision
+
+These are components of our stack that have been reduced to finalists.
+
+### :satellite: Web Framework
+
+Currently performing in-house benchmarks for:
+- [axum](https://github.com/tokio-rs/axum)
+- [actix-web](https://actix.rs/)
+- [poem](https://github.com/poem-web/poem)
+
+### :mailbox: API Specification
+
+Currently performing in-house benchmarks for:
+- [OpenAPI/Swagger](https://www.openapis.org/)
+- [GraphQL](https://graphql.org/)
+- [tonic](https://github.com/hyperium/tonic), a Rust implementation of [gRPC](https://grpc.io/)
+
+### :family: Interprocess Communication (IPC)
+
+Currently doing in-house benchmarks for:
+- [ZeroMQ](https://zeromq.org/)
+- [tonic](https://github.com/hyperium/tonic), a Rust implementation of [gRPC](https://grpc.io/)
+
+### :watch: Benchmarks and Load Testing
+
+We're using the following framework(s) on a trial basis:
+- [Codename Taurus](https://gettaurus.org/) + JMeter
+
+
+## :construction: On Deck
+
+### :books: Database
+- Telemetry Storage
+- Flight Plans
+- Maintenance and Certification Records
+- Customer Rewards Information
+- Data Required By Civil Aviation Authorities
+
+### :video_game: Game Engine
+- Ground Control Station
+
+### :brain: ML & Deep Learning Frameworks
+- Simulation
+- Optimization

--- a/docs/contributing/guides/stacks/spearhead-stack.md
+++ b/docs/contributing/guides/stacks/spearhead-stack.md
@@ -1,0 +1,33 @@
+# Project Spearhead Stack
+
+## :triangular_ruler: CAD - *Fusion 360*
+
+Resources:
+- [Autodesk Fusion 360 Website](https://www.autodesk.com/products/fusion-360/overview?term=1-YEAR&tab=subscription)
+
+## :zap: eCAD - *KiCAD*
+
+Resources:
+- [KiCAD Website](https://www.kicad.org/)
+
+## :airplane: Flight Hardware - *Pixhawk 6C*
+Resources:
+- [6C Wiring Diagram](https://docs.px4.io/main/en/assembly/quick_start_pixhawk6c.html)
+
+
+## :computer: Flight Software Framework - *PX4 Autopilot*
+
+Resources:
+- [PX4 Autopilot Website](https://px4.io/software/software-overview/)
+
+##  :eyes: Flight Simulation - *Godot*
+
+:construction: [Arrow Simulation Repository (GitHub)](https://github.com/Arrow-air/Modelling-Simulation-and-Control) :construction:
+
+Resources:
+- [Godot Website](https://godotengine.org/)
+
+## Mathematics - *Octave*
+
+Resources:
+- [Octave Website](https://octave.org/)

--- a/docs/contributing/guides/stacks/spearhead-stack.md
+++ b/docs/contributing/guides/stacks/spearhead-stack.md
@@ -5,10 +5,10 @@
 Resources:
 - [Autodesk Fusion 360 Website](https://www.autodesk.com/products/fusion-360/overview?term=1-YEAR&tab=subscription)
 
-## :zap: eCAD - *KiCAD*
+## :zap: eCAD - *Eagle (Fusion 360)*
 
 Resources:
-- [KiCAD Website](https://www.kicad.org/)
+- [Eagle Website](https://www.autodesk.com/products/eagle/overview)
 
 ## :airplane: Flight Hardware - *Pixhawk 6C*
 Resources:
@@ -20,14 +20,14 @@ Resources:
 Resources:
 - [PX4 Autopilot Website](https://px4.io/software/software-overview/)
 
-##  :eyes: Flight Simulation - *Godot*
+##  :slot_machine: Flight Simulation - *Godot*
 
 :construction: [Arrow Simulation Repository (GitHub)](https://github.com/Arrow-air/Modelling-Simulation-and-Control) :construction:
 
 Resources:
 - [Godot Website](https://godotengine.org/)
 
-## Mathematics - *Octave*
+## :heavy_division_sign: Matrix Programming - *Octave*
 
 Resources:
 - [Octave Website](https://octave.org/)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -154,6 +154,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['rust', 'toml']
       },
     }),
 };


### PR DESCRIPTION
Adds "Stacks" section under "Guides"

Adds a stack page each for Spearhead (intentionally minimal, to allow them to fill) and Services.

Adds the start of a Rust crash course specific to Rust concepts used by Arrow.

Looks nice on docusaurus:
![image](https://user-images.githubusercontent.com/6334638/184011550-238d3301-73c7-4fa6-91a5-3b4e4d82c43f.png)
