### PR TITLE
chore: update release checklist

### DIFF
--- a/docs/contributing/guides/release-checklist.md
+++ b/docs/contributing/guides/release-checklist.md
@@ -27,7 +27,7 @@ Why not create a `develop` -> `main` PR for the review?
 ### :mag: Hold Review
 
 1. Inform peer reviewer(s) and await review comments.
-2. Push review fixes to your `r#-final-review` branch.
+2. Push review fixes to your `r#-final-review` branch *as a new commit* (i.e. "fix: address final review comments")
 3. After approval(s), when your code is passing all CI checks, you may merge to `main`.
 
 ### :broom: Cleanup
@@ -59,6 +59,7 @@ Please paste the following comment template into the review:
   - [ ] Accurate installation instructions
   - [ ] Current links to other documents
   - [ ] Arrow DAO links
+- [ ] Any instance of :construction: should genuinely be under construction
 
 ## Code (not applicable to examples/ folder)
 - [ ] No unhandled unwrap()s
@@ -67,16 +68,23 @@ Please paste the following comment template into the review:
 - [ ] Function arguments checked where possible
 - [ ] Sufficient logger (info, warn, and debug) messages
 - [ ] Sensible Types (unsigned vs. signed)
+- [ ] No `#[allow(dead_code)]` without good reason
+- [ ] End all error, info, and debug messages with punctuation (periods, etc.)
+- [ ] No FIXMEs or TODOs without a projected release (`TODO R4: etc.`)
 
 ## REST API
 - [ ] Return codes accurately documented with openapi
 - [ ] Return codes make sense
 - [ ] Sufficiently descriptive error messages
+- [ ] Do NOT reflect a user's bad input back at them in replies.
+    - i.e. "Warning: '{}' is not a valid entry." should instead be "Warning: invalid entry."
+    - Use debug messages to see the invalid argument.
 
 ## Cargo.toml(s)
 - [ ] Package versions correct
 - [ ] No minor versions specified
 - [ ] Links to crates.io package, not git branch
+- [ ] Must have `license-file = "LICENSE"` under `[package]`
 ```
 
 (Confirm items with an `x`, e.g. `- [x] Lorem ipsum`)


### PR DESCRIPTION
edit: removed thomas's calendly link because it lead to a 404