### PR TITLE
fix: openapi merge health path overlap

### DIFF
--- a/.link-checker.config.json
+++ b/.link-checker.config.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "{link}"
+    },
+    {
+      "pattern": "twitter"
     }
   ],
   "httpHeaders": [

--- a/develop.openapi-merge.json
+++ b/develop.openapi-merge.json
@@ -2,18 +2,40 @@
   "inputs": [
     {
       "inputURL": "https://www.arrowair.com/api-docs/rest/svc-cargo/develop/openapi.json",
+      "pathModification": {
+        "stripStart": "/cargo",
+        "prepend": "/cargo"
+      },
       "description": {
         "append": true
       }
     },
     {
       "inputURL": "https://www.arrowair.com/api-docs/rest/svc-telemetry/develop/openapi.json",
+      "pathModification": {
+        "stripStart": "/telemetry",
+        "prepend": "/telemetry"
+      },
       "description": {
         "append": true
       }
     },
     {
       "inputURL": "https://www.arrowair.com/api-docs/rest/svc-assets/develop/openapi.json",
+      "pathModification": {
+        "stripStart": "/assets",
+        "prepend": "/assets"
+      },
+      "description": {
+        "append": true
+      }
+    },
+    {
+      "inputURL": "https://www.arrowair.com/api-docs/rest/svc-atc/develop/openapi.json",
+      "pathModification": {
+        "stripStart": "/atc",
+        "prepend": "/atc"
+      },
       "description": {
         "append": true
       }

--- a/docs/documentation/contracts/guides/vesting.md
+++ b/docs/documentation/contracts/guides/vesting.md
@@ -13,7 +13,7 @@ These vesting contracts and tokens are distributed on the Optimism L2 network, w
 
 1. Bridge the amount of ARROW tokens required from the Arrow mainnet multisig over to the Arrow Optimism multisig.
 
-   - Check the latest [Optimism deployment](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts/deployments/mainnet#readme) and use the `L1StandardBridge` contract at `0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1`.
+   - Check the latest [Optimism deployment](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/README.md) and use the `L1StandardBridge` contract at `0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1`.
    - Approve the `L1StandardBridge` to spend the required number of ARROW tokens, calling `approve` on the ArrowToken contract at `0x736609D310B5F925531B5ad895925CB0586F6241`.
    - Deposit ARROW tokens to the L2 Optimism multisig, calling `depositERC20To` on the `L1StandardBridge`.
 

--- a/docs/documentation/references.md
+++ b/docs/documentation/references.md
@@ -27,7 +27,7 @@ Chinese open standard for EVs, seems they are trying to establish standards for 
 https://www.polestar-forum.com/threads/geely-holding-launches-open-source-electric-vehicle-architecture.495/
 
 Autoware Software Designed Vehicle standards, github to control systems below, full stack view of a control system
-https://www.autoware.org/autoware-open-ad-kit
+https://autoware.org/open-ad-kit/
 https://github.com/autocore-ai/SDV
 
 Interesting passive cooling system via internal radiators by battery pack


### PR DESCRIPTION
In the REST API, all /health checks are needed without the service prefix for the loadbalancer to be able to use the same health check for all services.
While merging the API docs, this resulted into errors since it doesn't support the same path's for different tags.
By stripping the /<service> path and appending it again, we now have the service prefix for the health checks as well.