### PR TITLE
fix: editorconfig and dead link cleanup

### DIFF
--- a/docs/about-arrow/_category_.json
+++ b/docs/about-arrow/_category_.json
@@ -1,9 +1,9 @@
 {
-	"label": "About Arrow",
-	"position": 1,
-	"collapsed": true,
-	"link": {
-		"type": "doc",
-		"id": "about-arrow/index"
-	}
+  "label": "About Arrow",
+  "position": 1,
+  "collapsed": true,
+  "link": {
+    "type": "doc",
+    "id": "about-arrow/index"
+  }
 }

--- a/docs/documentation/references.md
+++ b/docs/documentation/references.md
@@ -23,8 +23,6 @@ https://ree.auto/
 Fully open source looking chassis design from Open Motors
 https://www.openmotors.co/product/tabbyevo/
 
-Chinese open standard for EVs, seems they are trying to establish standards for EV architecture as we speak. 
-https://www.polestar-forum.com/threads/geely-holding-launches-open-source-electric-vehicle-architecture.495/
 
 Autoware Software Designed Vehicle standards, github to control systems below, full stack view of a control system
 https://autoware.org/open-ad-kit/

--- a/external-docs.json
+++ b/external-docs.json
@@ -1,9 +1,9 @@
 {
-	"project-quiver": {
-		"repo": "Arrow-air/project-quiver",
-		"branch": "main",
-		"docsPath": "docs",
-		"sidebarLabel": "Project Quiver",
-		"sidebarPosition": 4
-	}
+  "project-quiver": {
+    "repo": "Arrow-air/project-quiver",
+    "branch": "main",
+    "docsPath": "docs",
+    "sidebarLabel": "Project Quiver",
+    "sidebarPosition": 4
+  }
 }


### PR DESCRIPTION
Fixes CI failures:

- `docs/about-arrow/_category_.json` — tabs → spaces
- `external-docs.json` — tabs → spaces
- `docs/documentation/references.md` — removed dead polestar-forum link

These were causing the Code Style Check and Markdown Broken Link Checker to fail.