### PR TITLE
Responsive improvements and copy cleanup

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1254,6 +1254,7 @@ figcaption {
 
 .heading-style-h4.problem-solution {
   font-size: 1.25rem;
+  text-align: left;
 }
 
 .text-style-italic {
@@ -2847,7 +2848,7 @@ figcaption {
 }
 
 .arrow-community-gallery_image-wrapper {
-  border-radius: var(--_ui-styles---radius--medium);
+  border-radius: 0;
   width: 100%;
   overflow: hidden;
 }
@@ -2919,7 +2920,7 @@ figcaption {
 .section_help-us-grow_item {
   border: 1px solid var(--_primitives---opacity--white-15);
   background-color: var(--_primitives---opacity--white-5);
-  border-radius: 8px;
+  border-radius: 0;
   flex-direction: column;
   align-items: center;
   width: 100%;
@@ -4491,9 +4492,13 @@ figcaption {
 
   .arrow-collab_content {
     grid-column-gap: 3rem;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     grid-auto-flow: row;
     min-height: auto;
+  }
+
+  .arrow-collab_content-right {
+    order: -1;
   }
 
   .arrow-collab_lightbox-image {
@@ -4560,8 +4565,8 @@ figcaption {
   }
 
   .arrow-what-is_row {
-    grid-column-gap: 2rem;
-    grid-row-gap: 2rem;
+    grid-column-gap: 1rem;
+    grid-row-gap: 1rem;
   }
 
   .arrow-what-is_content {
@@ -4600,6 +4605,7 @@ figcaption {
 
   .arrow-solution_list {
     grid-column-gap: 2rem;
+    grid-template-columns: 1fr 1fr;
   }
 
   .quiver-video-overlay_list {
@@ -5221,6 +5227,16 @@ figcaption {
 }
 
 @media screen and (max-width: 479px) {
+  .button-group {
+    display: inline-flex;
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .button-group .button {
+    justify-content: flex-start;
+  }
+
   h1, h2 {
     font-size: 2.5rem;
   }
@@ -5331,7 +5347,20 @@ figcaption {
   }
 
   .heading-style-h1 {
-    font-size: 2.75rem;
+    font-size: 2.25rem;
+  }
+
+  .arrow-hero_content {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .magic0happens-lottie {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .spinning-avatars {
+    display: none;
   }
 
   .text-size-tiny {
@@ -5430,7 +5459,7 @@ figcaption {
   }
 
   .arrow-hero_image {
-    transform: scale3d(1none, 1none, 1none);
+    transform: scale(1.1);
   }
 
   .arrow-hero_content, .arrow-problem_list, .arrow-open_content {

--- a/templates/pages/index.body.html
+++ b/templates/pages/index.body.html
@@ -184,7 +184,7 @@
                         <h2 class="heading-style-h2">Start with Drones<br>End with Flying Cars</h2>
                       </div>
                       <div class="margin-bottom text-align-center">
-                        <p class="text-size-medium">We're not building a flying car and hoping it works. We're starting with drones — shipping real aircraft, learning from real flights, and scaling up deliberately.<br><br>Each project funds the next. Each flight teaches the next.</p>
+                        <p class="text-size-medium">We're not building a flying car and hoping it works. We're starting with drones - shipping real aircraft, learning from real flights, and scaling up deliberately.<br><br>Each project funds the next. Each flight teaches the next.</p>
                       </div>
                       <div class="margin-top margin-medium">
                         <div class="button-group is-center">
@@ -328,7 +328,7 @@
                     <div class="margin-bottom margin-xxsmall">
                       <h3 class="heading-style-h4 problem-solution">Aerospace Is a Walled Garden</h3>
                     </div>
-                    <p class="paragraph problem">Try to build on what exists — you can't. Designs are locked up, manufacturing is centralized, and decades of institutional knowledge are guarded in secrecy. There's no open platform to start from.</p>
+                    <p class="paragraph problem">Try to build on what exists - you can't. Designs are locked up, manufacturing is centralized, and decades of institutional knowledge are guarded in secrecy. There's no open platform to start from.</p>
                   </div>
                   <div class="arrow-problem_item problem-solving">
                     <div class="margin-bottom margin-small">
@@ -407,17 +407,15 @@
             <div class="padding-section-large">
               <div class="arrow-solution_component">
                 <div class="margin-bottom margin-xxlarge">
-                  <div class="text-align-center">
-                    <div class="max-width-large align-center">
+                    <div class="max-width-large">
                       <div class="margin-bottom margin-xsmall">
                         <div class="text-style-tagline">The Arrow Thesis</div>
                       </div>
                       <div class="margin-bottom margin-small">
                         <h2 class="heading-style-h2">How We Win</h2>
                       </div>
-                      <p class="text-size-medium">Big budgets and closed systems haven't cracked this. We're betting on something different — open designs, distributed teams, and a funding model built for hardware. Here's the playbook.</p>
+                      <p class="text-size-medium">Big budgets and closed systems haven't cracked this. We're betting on something different - open designs, distributed teams, and a funding model built for hardware. Here's the playbook.</p>
                     </div>
-                  </div>
                 </div>
                 <div class="w-layout-grid arrow-solution_list">
                   <div class="arrow-solution_item">

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -65,7 +65,7 @@
                                   </svg></div>
                               </div>
                               <div class="arrow-navbar_item-text">
-                                <div class="text-weight-semibold is-mega-menu">Hardware Bounties &amp; Grants</div>
+                                <div class="text-weight-semibold is-mega-menu">Bounties &amp; Grants</div>
                                 <p class="text-size-small is-mega-menu">View available bounties and apply for grants</p>
                               </div>
                             </a>
@@ -76,8 +76,8 @@
                                   </svg></div>
                               </div>
                               <div class="arrow-navbar_item-text">
-                                <div class="text-weight-semibold is-mega-menu">How to Contribute [Engineering]</div>
-                                <p class="text-size-small is-mega-menu">A comprehensive guide to contributing to Arrow</p>
+                                <div class="text-weight-semibold is-mega-menu">How to Contribute</div>
+                                <p class="text-size-small is-mega-menu">Engineering at Arrow</p>
                               </div>
                             </a>
                           </div>
@@ -162,8 +162,8 @@
                                   </svg></div>
                               </div>
                               <div class="arrow-navbar_item-text">
-                                <div class="text-weight-semibold is-mega-menu">Arrow Improvement Proposals (AIPS)</div>
-                                <p class="text-size-small is-mega-menu">All Arrow Improvement Proposals (Github repo)</p>
+                                <div class="text-weight-semibold is-mega-menu">AIPS</div>
+                                <p class="text-size-small is-mega-menu">Arrow Improvement Proposals</p>
                               </div>
                             </a>
                             <a href="#" class="arrow-navbar_dropdown-link w-inline-block">


### PR DESCRIPTION
## Summary
- Fix mobile/tablet responsive layout issues across multiple breakpoints (991px, 767px, 479px)
- Clean up homepage copy: replace em-dashes with simple dashes, remove alignment wrappers from Arrow Thesis section
- Shorten navbar mega menu labels for better fit

## Changes
- **CSS (main.css):** Fix hero section overflow at 479px (Lottie width, grid minmax), stack hero buttons with column-reverse, progressive h1 sizing, stack collab section at 991px, reduce grid gaps, hide spinning avatars at 479px, zero border-radius on gallery and help-us-grow items, fix invalid scale3d transform
- **HTML (index.body.html):** Replace em-dashes with dashes, clean up Arrow Thesis section markup
- **Navbar (navbar.html):** Shorten labels - "Bounties & Grants", "How to Contribute", "AIPS"

## Test plan
- [ ] Verify responsive layout at 479px, 767px, and 991px breakpoints
- [ ] Check hero section doesn't overflow on small screens
- [ ] Confirm navbar mega menu labels display correctly
- [ ] Verify button stacking order in hero section on mobile