### PR TITLE
Retro-technical docs theme: custom navbar, sidebar, and content styling

### DIFF
--- a/docs/about-arrow/_category_.json
+++ b/docs/about-arrow/_category_.json
@@ -1,7 +1,8 @@
 {
   "label": "About Arrow",
   "position": 1,
-  "collapsed": true,
+  "collapsible": false,
+  "collapsed": false,
   "link": {
     "type": "doc",
     "id": "about-arrow/index"

--- a/docs/about-arrow/index.md
+++ b/docs/about-arrow/index.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 slug: /intro
+hide_table_of_contents: true
 ---
 
 # About Arrow

--- a/docs/about-arrow/manufacturing.md
+++ b/docs/about-arrow/manufacturing.md
@@ -2,6 +2,7 @@
 sidebar_position: 2
 slug: /manufacturing
 description: How Arrow coordinates open source hardware manufacturing through a decentralized network of community manufacturers.
+hide_table_of_contents: true
 sidebar_custom_props:
   icon: gear
 ---

--- a/docs/contributing/_category_.json
+++ b/docs/contributing/_category_.json
@@ -1,5 +1,6 @@
 {
   "label": "Contribute",
   "position": 2,
-  "collapsed": true
+  "collapsible": false,
+  "collapsed": false
 }

--- a/docs/contributing/guides/release-checklist.md
+++ b/docs/contributing/guides/release-checklist.md
@@ -5,9 +5,9 @@ draft: true # Not currently using this workflow - needs revision for our needs
 
 # Release Checklist
 
-## :bust_in_silhouette: Developer
+## Developer
 
-### :hatching_chick: Create an End-of-Release Review
+### Create an End-of-Release Review
 
 1. Create a new branch from `develop`.
 
@@ -30,18 +30,18 @@ Why not create a `develop` -> `main` PR for the review?
 - `develop` is a protected branch that can only be pushed into through a PR.
 - Using an unprotected branch `r#-final-review` allows direct pushes to address review comments.
 
-### :mag: Hold Review
+### Hold Review
 
 1. Inform peer reviewer(s) and await review comments.
 2. Push review fixes to your `r#-final-review` branch *as a new commit* (i.e. "fix: address final review comments")
 3. After approval(s), when your code is passing all CI checks, you may merge to `main`.
 
-### :broom: Cleanup
+### Cleanup
 
 1. Since `develop` also needs the changes added to `r#-final-review`, open a PR to merge `main` into `develop`.
 2. Have the same reviewers approve the PR.
 
-## :busts_in_silhouette: Peer Reviewers
+## Peer Reviewers
 
 This is the *last chance* for a review of the code before it is immortalized forever as a new release.
 

--- a/docs/documentation/_category_.json
+++ b/docs/documentation/_category_.json
@@ -1,5 +1,6 @@
 {
   "label": "Documentation",
   "position": 5,
-  "collapsed": true
+  "collapsible": false,
+  "collapsed": false
 }

--- a/docs/documentation/contracts/index.md
+++ b/docs/documentation/contracts/index.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: Introduction
+hide_table_of_contents: true
 ---
 
 # Introduction to Arrow Contracts

--- a/docs/kitchen-sink.md
+++ b/docs/kitchen-sink.md
@@ -124,7 +124,7 @@ This is a danger admonition.
 
 ## Images
 
-![Placeholder](https://via.placeholder.com/600x200?text=Sample+Image)
+![Placeholder](https://placehold.co/600x200/f0f0f0/999?text=Sample+Image&font=source-sans-pro)
 
 ---
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,6 +45,10 @@ const config = {
     ],
   ],
 
+  clientModules: [
+    require.resolve('./src/js/imageCollapse.js'),
+  ],
+
   plugins: [
     require.resolve('./plugins/dev-homepage'),
   ],
@@ -110,7 +114,9 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       colorMode: {
-        disableSwitch: true,
+        defaultMode: 'light',
+        disableSwitch: false,
+        respectPrefersColorScheme: false,
       },
       docs: {
         sidebar: {
@@ -125,25 +131,20 @@ const config = {
         },
         items: [
           {
-            type: "doc",
-            docId: "about-arrow/index",
+            type: "search",
             position: "right",
-            label: "Docs",
-            className: "text-secondary",
           },
           {
-            to: "/blog",
+            href: "https://github.com/Arrow-air",
             position: "right",
-            label: "Blog",
-            className: "text-secondary",
-            image: "img/arrow-icon_blog.svg",
+            className: "navbar-icon navbar-icon--github",
+            "aria-label": "GitHub",
           },
           {
             href: "https://discord.com/invite/arrow",
             position: "right",
-            label: "Discord",
-            className: "text-secondary",
-            image: "img/arrow-icon_discord.svg",
+            className: "navbar-icon navbar-icon--discord",
+            "aria-label": "Discord",
           },
         ],
       },

--- a/scripts/import-external-docs.sh
+++ b/scripts/import-external-docs.sh
@@ -102,7 +102,8 @@ for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
 {
 	"label": "${sidebar_label}",
 	"position": ${sidebar_position},
-	"collapsed": true,
+	"collapsible": false,
+	"collapsed": false,
 	"link": {
 		"type": "doc",
 		"id": "${key}/index"
@@ -115,7 +116,8 @@ EOF
 {
 	"label": "${sidebar_label}",
 	"position": ${sidebar_position},
-	"collapsed": true,
+	"collapsible": false,
+	"collapsed": false,
 	"link": {
 		"type": "generated-index",
 		"description": "Documentation for ${sidebar_label}"

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -68,7 +68,7 @@ html, body {
 }
 
 h1, h2, h3, h4, h5 {
-    font-family: 'Neue Haas Grotesk', sans-serif!important;
+    font-family: 'Neue Haas Grotesk', sans-serif;
     font-weight: bold;
 }
 
@@ -98,8 +98,86 @@ ul {
 .navbar__items--right > :last-child {
     padding-right: calc( var(--ifm-button-padding-horizontal) * var(--ifm-button-size-multiplier) );
 }
-.nav-link svg {
-    display: none;
+
+nav[class*="navbar"] {
+    justify-content: center;
+}
+
+nav[class*="navbar"] > [class*="navbarInner"] {
+    max-width: 1600px;
+}
+
+/* Icon-only navbar items */
+.navbar-icon {
+  display: flex;
+  align-items: center;
+  width: 24px;
+  height: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 24px 24px;
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
+}
+
+.navbar-icon:hover {
+  opacity: 1;
+}
+
+.navbar-icon--github {
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' fill='%236b7280' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z'/%3E%3C/svg%3E");
+}
+
+.navbar-icon--discord {
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='%236b7280' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z'/%3E%3C/svg%3E");
+}
+
+/* ==========================================================================
+   NAVBAR SEARCH BAR — retro CLI style
+   ========================================================================== */
+
+.navbar__search-input {
+  font-family: 'Jetbrainsmono', monospace !important;
+  font-size: 11px !important;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  width: 240px !important;
+  height: 34px;
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  border: 1px solid rgba(255, 255, 255, 0.25) !important;
+  border-radius: 0 !important;
+  color: #ffffff !important;
+  padding: 0 2.5rem 0 2rem !important;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath fill='rgba(255,255,255,0.5)' d='M6.5 1a5.5 5.5 0 0 1 4.38 8.82l3.66 3.66a.75.75 0 0 1-1.06 1.06l-3.66-3.66A5.5 5.5 0 1 1 6.5 1m0 1.5a4 4 0 1 0 0 8a4 4 0 0 0 0-8'/%3E%3C/svg%3E") !important;
+  background-repeat: no-repeat !important;
+  background-position: 0.5rem center !important;
+  background-size: 16px 16px !important;
+  transition: background-color 0.15s ease, border-color 0.15s ease, width 0.2s ease;
+}
+
+.navbar__search-input::placeholder {
+  color: rgba(255, 255, 255, 0.5) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.navbar__search-input:focus {
+  width: 320px !important;
+  background-color: rgba(255, 255, 255, 0.15) !important;
+  border-color: rgba(255, 255, 255, 0.5) !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+/* Keyboard shortcut hints */
+.navbar__search .searchHintContainer .searchHint {
+  font-family: 'Jetbrainsmono', monospace !important;
+  font-size: 9px !important;
+  color: rgba(255, 255, 255, 0.4) !important;
+  background: rgba(255, 255, 255, 0.1) !important;
+  border: 1px solid rgba(255, 255, 255, 0.2) !important;
+  box-shadow: none !important;
+  border-radius: 0 !important;
 }
 
 .footer__logo {
@@ -330,17 +408,26 @@ h1, .h1 {
     h2, .h2 {
         font-size: 2rem!important;
     }
+    .theme-doc-markdown h2 {
+        font-size: 1.8rem!important;
+    }
 }
 
 @media (min-width: 1200px) {
     h3, .h3 {
         font-size: 1.75rem!important;
     }
+    .theme-doc-markdown h3 {
+        font-size: 1.4rem!important;
+    }
 }
 
 @media (min-width: 1200px) {
     h4, .h4 {
         font-size: 1.5rem!important;
+    }
+    .theme-doc-markdown h4 {
+        font-size: 1.1rem!important;
     }
 }
 
@@ -533,6 +620,9 @@ h1, .h1 {
   --docs-bg: #ffffff;
   --docs-bg-subtle: #f9fafb;
 
+  /* Content width */
+  --docs-content-max-width: 800px;
+
   /* Docusaurus overrides */
   --ifm-color-primary: #0843BF;
   --ifm-color-primary-dark: #073aab;
@@ -547,6 +637,7 @@ h1, .h1 {
   --ifm-menu-color: var(--docs-text-secondary);
   --ifm-menu-color-active: var(--docs-primary);
   --ifm-menu-color-background-active: var(--docs-primary-light);
+  --ifm-breadcrumb-item-background-active: transparent;
   --ifm-menu-color-background-hover: var(--docs-bg-subtle);
 }
 
@@ -556,6 +647,11 @@ h1, .h1 {
 
 .theme-doc-sidebar-container {
   border-right: 3px double #d1d5db;
+}
+
+/* Spacing between top-level sidebar sections */
+.theme-doc-sidebar-menu > .menu__list-item + .menu__list-item {
+  margin-top: 1.5rem;
 }
 
 /* TOP-LEVEL category labels only - Departure Mono, allcaps, black */
@@ -603,6 +699,10 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   background: transparent;
 }
 
+.menu__list-item-collapsible.menu__list-item-collapsible--active {
+  border-right: 1px solid rgba(0, 0, 0, 0.25);
+}
+
 /* Nested category labels (Level 2+) - normal case, regular weight */
 .menu__list .menu__list .menu__list-item > .menu__list-item-collapsible > .menu__link,
 .menu__list .menu__list .menu__list-item > .menu__list-item-collapsible .menu__link,
@@ -637,6 +737,10 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   font-weight: 500;
 }
 
+.menu__link--active:not(.menu__link--sublist) {
+  border-right: 1px solid var(--docs-primary);
+}
+
 .menu__link--active:hover {
   color: var(--docs-primary);
   background: var(--docs-primary-light);
@@ -652,6 +756,7 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 /* Category caret - custom chevron */
 .menu__caret {
   padding: 0.25rem;
+  padding-right: 1rem;
 }
 
 .menu__caret:hover {
@@ -698,6 +803,71 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 }
 
 /* ==========================================================================
+   SIDEBAR COLLAPSE / EXPAND BUTTONS — retro pixel style
+   ========================================================================== */
+
+/* Collapse button (bottom of sidebar) */
+[class*="collapseSidebarButton"] {
+  border: 1px solid var(--docs-border) !important;
+  border-left: none !important;
+  border-right: none !important;
+  background-color: transparent !important;
+  height: 36px !important;
+  transition: background-color 0.15s ease;
+}
+
+[class*="collapseSidebarButton"]:hover,
+[class*="collapseSidebarButton"]:focus {
+  background-color: var(--docs-bg-subtle) !important;
+}
+
+/* Hide default SVG icon */
+[class*="collapseSidebarButton"] svg {
+  display: none !important;
+}
+
+/* Pixel-art left-pointing double chevron */
+[class*="collapseSidebarButton"]::after {
+  content: '\00AB';  /* « */
+  font-family: 'Departure Mono', monospace;
+  font-size: 16px;
+  color: var(--docs-text-muted);
+  letter-spacing: 0.05em;
+}
+
+[class*="collapseSidebarButton"]:hover::after {
+  color: var(--docs-primary);
+}
+
+/* Expand button (thin strip when sidebar is hidden) */
+[class*="expandButton"] {
+  background-color: transparent !important;
+  transition: background-color 0.15s ease;
+}
+
+[class*="expandButton"]:hover,
+[class*="expandButton"]:focus {
+  background-color: var(--docs-bg-subtle) !important;
+}
+
+/* Hide default SVG icon */
+[class*="expandButton"] svg {
+  display: none !important;
+}
+
+/* Pixel-art right-pointing double chevron */
+[class*="expandButton"]::after {
+  content: '\00BB';  /* » */
+  font-family: 'Departure Mono', monospace;
+  font-size: 16px;
+  color: var(--docs-text-muted);
+}
+
+[class*="expandButton"]:hover::after {
+  color: var(--docs-primary);
+}
+
+/* ==========================================================================
    GLOBAL RESETS - No rounded corners
    ========================================================================== */
 
@@ -709,27 +879,66 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
    MAIN CONTENT - Typography & Markdown
    ========================================================================== */
 
+/* Markdown toggle: hide rendered content when viewing raw source */
+.theme-doc-markdown[data-md-show-raw] > *:not(.md-raw-content-portal) {
+  display: none !important;
+}
+
+/* Markdown toggle: hide TOC, footer, and pagination when viewing raw source */
+[class*="docMainContainer"]:has([data-md-show-raw]) [class*="col"]:has(nav[class*="tableOfContents"]),
+[class*="docMainContainer"]:has([data-md-show-raw]) [class*="tableOfContents"],
+[class*="docMainContainer"]:has([data-md-show-raw]) .table-of-contents,
+[class*="docMainContainer"]:has([data-md-show-raw]) .theme-doc-footer,
+[class*="docMainContainer"]:has([data-md-show-raw]) nav.pagination-nav,
+[class*="docMainContainer"]:has([data-md-show-raw]) .doc-end-bar-wrapper {
+  display: none !important;
+}
+
+/* Markdown toggle: flatten active breadcrumb background in raw view */
+[class*="docMainContainer"]:has([data-md-show-raw]) .breadcrumbs__item--active .breadcrumbs__link {
+  background: transparent !important;
+}
+
 /* Main docs container - add padding and constrain width */
 .theme-doc-markdown {
   font-family: 'Neue Haas Grotesk', sans-serif;
   font-size: 15px;
   line-height: 1.6;
   color: var(--docs-text-secondary);
-  max-width: 800px;
+  max-width: var(--docs-content-max-width);
   margin: 0 auto;
-  padding: 0 2rem;
+  padding: .5rem 2rem;
+}
+
+/* Doc root - consistent top spacing for sidebar + content */
+[class*="docRoot"] {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  max-width: 1600px;
+  margin: 0 auto;
 }
 
 /* Doc page wrapper padding */
-.docMainContainer_node_modules-\@docusaurus-theme-classic-lib-theme-DocPage-Layout-Main-styles-module {
-  padding: 1.5rem 2rem;
+[class*="docMainContainer"] {
+  padding: 0 2rem 1rem 2rem;
 }
 
-[class*="docMainContainer"] {
-  padding: 1.5rem 2rem;
-  display: flex;
-  justify-content: center;
+/* Tighten horizontal spacing on smaller viewports */
+@media (max-width: 996px) {
+  [class*="docMainContainer"] {
+    padding-left: 0.5rem !important;
+    padding-right: 0.5rem !important;
+  }
+  .theme-doc-markdown {
+    padding-left: 0.5rem !important;
+    padding-right: 0.5rem !important;
+  }
+  .container {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
 }
+
 
 [class*="docItemContainer"] {
   max-width: 900px;
@@ -742,61 +951,70 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 }
 
 /* Headings hierarchy */
+
+/* H1 — Page title. Bold sans-serif, double-rule underline */
 .theme-doc-markdown h1 {
   font-family: 'Neue Haas Grotesk', sans-serif;
   font-size: 2rem;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--docs-text);
-  margin: 0 0 1rem 0;
-  padding-bottom: 0.5rem;
-  border-bottom: 2px solid var(--docs-text);
-  letter-spacing: -0.01em;
+  margin: 0 0 1.25rem 0;
+  padding-bottom: 0.625rem;
+  border-bottom: 3px double var(--docs-text);
+  letter-spacing: -0.02em;
 }
 
+/* H2 — Section header. Bold sans-serif, blue tinted background */
 .theme-doc-markdown h2 {
   font-family: 'Neue Haas Grotesk', sans-serif;
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: var(--docs-text);
-  margin: 2rem 0 0.75rem 0;
+  font-size: 1.8rem !important;
+  font-weight: 700;
+  color: var(--docs-primary);
+  margin: 2.5rem 0 0.75rem 0;
   padding-bottom: 0.375rem;
+  border-bottom: 1px solid rgba(8, 67, 191, 0.2);
+}
+
+/* H3 — Subsection. Sans-serif with subtle underline */
+.theme-doc-markdown h3 {
+  font-family: 'Neue Haas Grotesk', sans-serif;
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: var(--docs-text);
+  margin: 1.75rem 0 0.5rem 0;
+  padding-bottom: 0.3rem;
   border-bottom: 1px solid var(--docs-border);
 }
 
-.theme-doc-markdown h3 {
-  font-family: 'Neue Haas Grotesk', sans-serif;
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: var(--docs-text);
-  margin: 1.5rem 0 0.5rem 0;
-}
-
+/* H4 — Label. Mono uppercase */
 .theme-doc-markdown h4 {
   font-family: 'Jetbrainsmono', monospace;
-  font-size: 13px;
-  font-weight: 500;
+  font-size: 1.1rem;
+  font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--docs-text-muted);
-  margin: 1.25rem 0 0.5rem 0;
+  color: var(--docs-text);
+  margin: 2rem 0 0.75rem 0;
 }
 
+/* H5 — Sublabel. Mono uppercase, primary accent */
 .theme-doc-markdown h5 {
   font-family: 'Jetbrainsmono', monospace;
-  font-size: 13px;
-  font-weight: 500;
+  font-size: 12px;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #0843BF;
-  margin: 1rem 0 0.375rem 0;
+  color: var(--docs-primary);
+  margin: 1.25rem 0 0.375rem 0;
 }
 
+/* H6 — Fine print label */
 .theme-doc-markdown h6 {
   font-family: 'Jetbrainsmono', monospace;
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 400;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   color: var(--docs-text-muted);
   margin: 1rem 0 0.375rem 0;
 }
@@ -805,6 +1023,7 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 .theme-doc-markdown p {
   margin: 0 0 0.875rem 0;
   color: var(--docs-text-secondary);
+  font-size: 1.1rem;
   line-height: 1.65;
 }
 
@@ -821,13 +1040,40 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 /* Links */
 .theme-doc-markdown a {
   color: var(--docs-primary);
-  text-decoration: none;
-  border-bottom: 1px solid transparent;
-  transition: border-color 0.15s ease;
+  text-decoration: underline;
+  text-decoration-color: var(--docs-primary-light, rgba(8, 67, 191, 0.3));
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+  transition: text-decoration-color 0.15s ease;
 }
 
 .theme-doc-markdown a:hover {
-  border-bottom-color: var(--docs-primary);
+  text-decoration-color: var(--docs-primary);
+}
+
+.theme-doc-markdown a[target="_blank"] {
+  white-space: nowrap;
+}
+
+.theme-doc-markdown a[target="_blank"]::after {
+  content: '';
+  display: inline-block;
+  width: 0.7em;
+  height: 0.7em;
+  margin-left: 0.2em;
+  vertical-align: baseline;
+  background-color: currentColor;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7 17L17 7'/%3E%3Cpath d='M7 7h10v10'/%3E%3C/svg%3E");
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7 17L17 7'/%3E%3Cpath d='M7 7h10v10'/%3E%3C/svg%3E");
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  transition: transform 0.2s ease;
+}
+
+.theme-doc-markdown a[target="_blank"]:hover::after {
+  transform: translate(1px, -1px);
 }
 
 /* ==========================================================================
@@ -841,8 +1087,8 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 }
 
 .theme-doc-markdown li {
-  margin-bottom: 0.25rem;
-  line-height: 1.5;
+  margin-bottom: 0.125rem;
+  line-height: 1.4;
 }
 
 .theme-doc-markdown ul {
@@ -862,11 +1108,14 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 
 .theme-doc-markdown ol {
   list-style-type: decimal;
+  font-size: 1.00rem;
+  line-height: 1.5;
+  padding-left: 2rem;
 }
 
 .theme-doc-markdown ol > li::marker {
   font-family: 'Jetbrainsmono', monospace;
-  font-size: 11px;
+  font-size: 1rem;
   color: var(--docs-text-muted);
 }
 
@@ -893,20 +1142,21 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   font-family: 'Jetbrainsmono', monospace;
   font-size: 13px;
   padding: 0.125rem 0.375rem;
-  background: var(--docs-bg-subtle);
-  border: 1px solid var(--docs-border);
+  background: #eef0f3;
+  border: 1px solid #d5d8dc;
   color: var(--docs-text);
 }
 
-/* Code blocks */
+/* Code blocks — matches note admonition style */
 .theme-doc-markdown pre {
   font-family: 'Jetbrainsmono', monospace;
   font-size: 13px;
   line-height: 1.5;
-  padding: 1rem;
+  padding: 1rem 1rem 1rem 0.5rem;
   margin: 0 0 1rem 0;
   background: var(--docs-bg-subtle);
-  border: 1px solid var(--docs-border);
+  border: 1px solid #d0d3d7;
+  box-shadow: 4px 4px 0 0 rgba(0, 0, 0, 0.05);
   overflow-x: auto;
 }
 
@@ -915,20 +1165,61 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   background: transparent;
   border: none;
   font-size: inherit;
+  counter-reset: line;
 }
 
-/* Code block title/label */
-.codeBlockTitle_node_modules-\@docusaurus-theme-classic-lib-theme-CodeBlock-Content-styles-module {
-  font-family: 'Jetbrainsmono', monospace;
-  font-size: 10px;
+/* Line numbers + hover highlight */
+.theme-doc-markdown pre code .token-line {
+  display: inline-block;
+  width: 100%;
+  padding: 0 0.5rem 0 4.5rem;
+  margin: 0 -0.5rem;
+  text-indent: -4.5rem;
+  counter-increment: line;
+}
+
+.theme-doc-markdown pre code .token-line::before {
+  content: counter(line);
+  display: inline-block;
+  width: 2rem;
+  margin-right: 1.5rem;
+  padding-right: 1rem;
+  text-align: right;
+  color: #c0c4c8;
+  font-size: 11px;
+  user-select: none;
+  border-right: 1px solid #e0e2e5;
+}
+
+/* Code blocks start with word wrap on */
+.theme-doc-markdown pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Subtle hover highlight */
+.theme-doc-markdown pre code .token-line:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+/* Docusaurus highlighted lines */
+.theme-doc-markdown .docusaurus-highlight-code-line,
+.theme-doc-markdown pre code .token-line.highlight-line {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+/* Code block title/label — dark title bar like admonitions */
+[class*="codeBlockTitle"] {
+  font-family: 'Departure Mono', 'Jetbrainsmono', monospace;
+  font-size: 11px;
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 0.5rem 1rem;
-  background: var(--docs-border);
-  border: 1px solid var(--docs-border);
-  border-bottom: none;
-  color: var(--docs-text-muted);
+  letter-spacing: 0.1em;
+  padding: 0.4rem 1rem;
+  background: #b1b5b9;
+  border: 1px solid #d0d3d7;
+  border-bottom: 2px solid #b1b5b9;
+  color: #ffffff;
 }
 
 /* ==========================================================================
@@ -938,13 +1229,15 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 .theme-doc-markdown table {
   font-family: 'Jetbrainsmono', monospace;
   font-size: 13px;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   width: fit-content;
   max-width: 100%;
   line-height: 1.4;
   margin: 0 0 1rem 0;
-  border: 1px solid var(--docs-border);
-  display: table;
+  display: block;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .theme-doc-markdown th {
@@ -955,29 +1248,36 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   letter-spacing: 0.05em;
   text-align: left;
   padding: 0.5rem 0.75rem;
-  background: var(--docs-bg-subtle);
-  border-bottom: 1px solid var(--docs-border);
-  border-right: 1px solid var(--docs-border);
+  background: #eceef0;
+  border: none;
+  border-top: 1px solid var(--docs-border);
+  border-bottom: 2px solid var(--docs-border);
+  border-left: 1px solid var(--docs-border);
   color: #0843BF;
 }
 
 .theme-doc-markdown th:last-child {
-  border-right: none;
+  border-right: 1px solid var(--docs-border);
 }
 
 .theme-doc-markdown td {
   padding: 0.375rem 0.75rem;
-  border-bottom: 1px solid var(--docs-border);
-  border-right: 1px solid var(--docs-border);
+  border: none;
+  border-top: 1px solid var(--docs-border);
+  border-left: 1px solid var(--docs-border);
   color: var(--docs-text-secondary);
 }
 
 .theme-doc-markdown td:last-child {
-  border-right: none;
+  border-right: 1px solid var(--docs-border);
+}
+
+.theme-doc-markdown tbody tr:first-child td {
+  border-top: none;
 }
 
 .theme-doc-markdown tr:last-child td {
-  border-bottom: none;
+  border-bottom: 1px solid var(--docs-border);
 }
 
 .theme-doc-markdown tr:hover td {
@@ -1000,20 +1300,131 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   margin-bottom: 0;
 }
 
-/* Docusaurus admonitions */
+/* ==========================================================================
+   ADMONITIONS — utilitarian callout style
+   ========================================================================== */
+
+/* Base admonition — industrial label style */
 .alert {
-  border: 1px solid var(--docs-border);
-  padding: 0.75rem 1rem;
-  margin-bottom: 1rem;
+  --adm-bg: #f0efe8;
+  --adm-border: #1f2937;
+  background: var(--adm-bg);
+  border: 2px solid var(--adm-border);
+  box-shadow: 4px 4px 0 0 rgba(0, 0, 0, 0.12);
+  padding: 0;
+  margin: 2.5rem 0;
+  color: var(--adm-border);
+  font-size: 14px;
+  line-height: 1.6;
 }
 
-.alert .admonitionHeading_node_modules-\@docusaurus-theme-classic-lib-theme-Admonition-Layout-styles-module {
-  font-family: 'Jetbrainsmono', monospace;
-  font-size: 10px;
+/* Page-level alerts (e.g. draft banner) — match content padding */
+[class*="docMainContainer"] .alert:not(.theme-doc-markdown .alert) {
+  max-width: var(--docs-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 2rem;
+}
+
+.theme-draft-banner {
+  margin-left: 30px !important;
+  margin-right: 30px !important;
+}
+
+[class*="docMainContainer"] .alert:not(.theme-doc-markdown .alert) [class*="admonitionContent"] {
+  padding: 0.75rem 30px;
+}
+
+/* Title bar — solid dark bar, white text, old OS window style */
+.alert [class*="admonitionHeading"] {
+  font-family: 'Departure Mono', 'Jetbrainsmono', monospace !important;
+  font-size: 11px !important;
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 0.5rem;
+  letter-spacing: 0.1em;
+  margin: 0;
+  padding: 0.4rem 1rem;
+  border-bottom: 2px solid var(--adm-border);
+  background: var(--adm-border);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  position: relative;
+}
+
+/* Window controls — _ x */
+.alert [class*="admonitionHeading"]::after {
+  content: '\2013\00a0\00a0\d7';
+  font-family: 'Departure Mono', 'Jetbrainsmono', monospace;
+  font-size: 12px;
+  letter-spacing: 0;
+  margin-left: auto;
+  opacity: 0.6;
+  color: #ffffff;
+}
+
+.alert [class*="admonitionHeading"] svg {
+  fill: #ffffff;
+  stroke: #ffffff;
+  color: #ffffff;
+}
+
+/* Content area */
+.alert [class*="admonitionContent"] {
+  padding: 0.75rem 1rem;
+  color: var(--adm-border);
+}
+
+.alert [class*="admonitionContent"] p {
+  color: var(--adm-border);
+}
+
+.alert [class*="admonitionContent"] p:last-child {
+  margin-bottom: 0;
+}
+
+.alert [class*="admonitionContent"] a {
+  color: var(--adm-border);
+  border-bottom-color: var(--adm-border);
+}
+
+.alert [class*="admonitionContent"] code {
+  background: rgba(0, 0, 0, 0.06);
+  border: 1px solid var(--adm-border);
+  color: var(--adm-border);
+}
+
+/* --- Type colors --- */
+
+/* Note — neutral gray */
+.alert--note {
+  --adm-bg: #f5f5f3;
+  --adm-border: #b1b5b9;
+}
+
+/* Tip — green */
+.alert--tip {
+  --adm-bg: #f0f7ec;
+  --adm-border: #3d8b37;
+}
+
+/* Info — blue */
+.alert--info {
+  --adm-bg: #edf2fc;
+  --adm-border: #2563eb;
+}
+
+/* Caution/Warning — amber */
+.alert--warning {
+  --adm-bg: #fef8ec;
+  --adm-border: #d97706;
+}
+
+/* Danger — red */
+.alert--danger {
+  --adm-bg: #fdf2f2;
+  --adm-border: #dc2626;
 }
 
 /* ==========================================================================
@@ -1033,56 +1444,156 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 .theme-doc-markdown img {
   max-width: 100%;
   height: auto;
-  border: 1px solid var(--docs-border);
-  margin: 0.5rem 0;
+  border: 1px solid #d0d3d7;
+  border-top: none;
+  box-shadow: 4px 4px 0 0 rgba(0, 0, 0, 0.05);
+  margin: 0;
+  display: block;
 }
 
+/* Retro OS window wrapper for standalone images */
+.theme-doc-markdown p > img,
+.theme-doc-markdown figure > img {
+  margin-top: 0;
+}
+
+.theme-doc-markdown p:has(> img),
 .theme-doc-markdown figure {
-  margin: 1rem 0;
+  position: relative;
+  margin: 1.5rem 0;
+  border: 1px solid #D5D8DC;
+  box-shadow: 4px 4px 0 0 rgba(0, 0, 0, 0.05);
+  padding: 0 0.5rem 1.1rem 0.5rem;
+  background:
+    linear-gradient(#EEF0F3, #EEF0F3) top left / 100% calc(100% - 0.6rem) no-repeat,
+    repeating-linear-gradient(
+      -45deg,
+      #D5D8DC 0px,
+      #D5D8DC 1px,
+      #EEF0F3 1px,
+      #EEF0F3 5px
+    );
+}
+
+.theme-doc-markdown p:has(> img)::before,
+.theme-doc-markdown figure::before {
+  content: 'IMAGE';
+  display: block;
+  font-family: 'Departure Mono', 'Jetbrainsmono', monospace;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.4rem 1rem;
+  background: #E2E4E8;
+  border-bottom: 1px solid #D5D8DC;
+  color: #4b5563;
+  margin: 0 -0.5rem 0.5rem -0.5rem;
+}
+
+/* Minimize button — replaces ::after, now functional */
+.image-collapse-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-family: 'Departure Mono', 'Jetbrainsmono', monospace;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0.4rem 0.75rem;
+  color: #4b5563;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
+}
+
+.image-collapse-btn:hover {
+  opacity: 1;
+}
+
+/* Collapsed state */
+.image-collapsed img {
+  display: none;
+}
+
+.image-collapsed {
+  padding-bottom: 0 !important;
+  background: #EEF0F3 !important;
+}
+
+/* Images inside the window — no double border/shadow */
+.theme-doc-markdown p:has(> img) > img,
+.theme-doc-markdown figure > img {
+  border: none;
+  box-shadow: none;
 }
 
 .theme-doc-markdown figcaption {
-  font-family: 'Jetbrainsmono', monospace;
+  font-family: 'Departure Mono', 'Jetbrainsmono', monospace;
   font-size: 10px;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
   color: var(--docs-text-muted);
-  margin-top: 0.5rem;
+  padding: 0.4rem 1rem;
+  border-top: 1px solid #d0d3d7;
 }
 
 /* ==========================================================================
    DETAILS / ACCORDION
    ========================================================================== */
 
-.theme-doc-markdown details {
-  border: 1px solid var(--docs-border);
+.theme-doc-markdown details,
+.theme-doc-markdown details[class*="details"] {
+  border: none !important;
+  background: none !important;
+  box-shadow: none !important;
   margin: 0 0 1rem 0;
+  padding: 0;
 }
 
 .theme-doc-markdown summary {
-  font-family: 'Jetbrainsmono', monospace;
-  font-size: 12px;
-  font-weight: 500;
-  padding: 0.625rem 1rem;
-  background: var(--docs-bg-subtle);
   cursor: pointer;
+  padding: 0.4rem 0 0.4rem 1.25rem;
   color: var(--docs-text);
+  font-size: 0.95rem;
+  background: none !important;
+  position: relative;
+}
+
+/* Hide Docusaurus custom arrow */
+.theme-doc-markdown summary::before {
+  border: none !important;
+  content: '\203A' !important;
+  position: absolute;
+  left: 0;
+  top: 0.35rem;
+  font-size: 1.1em;
+  font-weight: 600;
+  color: var(--docs-text-muted);
+  transform: rotate(0deg);
+  transition: transform 0.15s ease;
+}
+
+.theme-doc-markdown details[open] > summary::before,
+.theme-doc-markdown details[data-collapsed="false"] > summary::before {
+  transform: rotate(90deg) !important;
 }
 
 .theme-doc-markdown summary:hover {
-  background: var(--docs-border);
+  color: var(--docs-primary);
+}
+
+.theme-doc-markdown summary:hover::before {
+  color: var(--docs-primary);
 }
 
 .theme-doc-markdown details[open] summary {
-  border-bottom: 1px solid var(--docs-border);
+  margin-bottom: 0.25rem;
 }
 
 .theme-doc-markdown details > *:not(summary) {
-  padding: 0 1rem;
-}
-
-.theme-doc-markdown details > p:first-of-type {
-  padding-top: 0.75rem;
+  padding: 0 0 0 1.25rem;
 }
 
 /* ==========================================================================
@@ -1126,6 +1637,49 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
    TOC (Table of Contents)
    ========================================================================== */
 
+/* Mobile TOC — match .theme-doc-markdown layout */
+.theme-doc-toc-mobile {
+  max-width: var(--docs-content-max-width) !important;
+  margin: 0.5rem 2rem !important;
+}
+
+/* Hide TOC column on viewports <= 1279px and let content expand */
+@media (max-width: 1279px) {
+  [class*="col"]:has([class*="tableOfContents"]) {
+    display: none !important;
+  }
+  [class*="tableOfContents"],
+  .theme-doc-toc-desktop {
+    display: none !important;
+  }
+  [class*="docMainContainer"] [class*="docItemCol"] {
+    max-width: 100% !important;
+    flex-basis: 100% !important;
+    flex-grow: 1 !important;
+  }
+}
+
+/* Show TOC column on viewports >= 1280px */
+@media (min-width: 1280px) {
+  /* Make content column 75% when TOC sibling exists */
+  [class*="docItemCol"]:not(:only-child) {
+    max-width: 75% !important;
+    flex-basis: 75% !important;
+  }
+  /* Show the TOC column */
+  [class*="col"]:has(nav[class*="tableOfContents"]) {
+    display: block !important;
+    max-width: 25% !important;
+    flex-basis: 25% !important;
+  }
+}
+
+/* Expand content column when no TOC column is present */
+[class*="docItemCol"]:only-child {
+  max-width: 100% !important;
+  flex-basis: 100% !important;
+}
+
 .table-of-contents {
   font-family: 'Neue Haas Grotesk', sans-serif;
   font-size: 12px;
@@ -1164,9 +1718,23 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
    PAGINATION
    ========================================================================== */
 
+.pagination-nav {
+  max-width: var(--docs-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 30px;
+}
+
 .pagination-nav__link {
-  border: 1px solid var(--docs-border);
+  border: 1px solid var(--docs-primary);
   padding: 0.75rem 1rem;
+  border-radius: 0;
+  transition: background-color 0.15s ease;
+}
+
+.pagination-nav__link:hover {
+  border-color: var(--docs-primary);
+  background-color: rgba(8, 67, 191, 0.05);
 }
 
 .pagination-nav__sublabel {
@@ -1174,13 +1742,14 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--docs-text-muted);
+  color: var(--docs-primary);
 }
 
 .pagination-nav__label {
   font-family: 'Neue Haas Grotesk', sans-serif;
   font-size: 14px;
-  color: var(--docs-text);
+  font-weight: 600;
+  color: var(--docs-primary);
 }
 
 /* Custom angular carets for pagination */
@@ -1190,7 +1759,7 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   width: 6px;
   height: 6px;
   border-style: solid;
-  border-color: var(--docs-text-muted);
+  border-color: var(--docs-primary);
   border-width: 0 1.5px 1.5px 0;
   transition: border-color 0.15s ease;
 }
@@ -1211,7 +1780,97 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 
 .pagination-nav__link:hover .pagination-nav__label::before,
 .pagination-nav__link:hover .pagination-nav__label::after {
-  border-color: #0843BF;
+  border-color: var(--docs-primary);
+}
+
+/* ==========================================================================
+   END-OF-CONTENT BAR (Discord CTA + Edit button)
+   ========================================================================== */
+
+.doc-end-bar-wrapper {
+  max-width: var(--docs-content-max-width);
+  margin: 1.5rem auto 0;
+  padding: 0 30px;
+}
+
+.doc-end-bar {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  border: 1px solid var(--docs-border);
+  border-bottom: 3px solid var(--docs-border);
+  background: var(--ifm-background-color);
+}
+
+/* Message text — sits flush left inside the bar */
+.doc-end-bar__message {
+  font-family: 'Jetbrainsmono', monospace;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--docs-text-muted);
+  padding: 0.5rem 0.75rem;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* "Discord" link within the message */
+.doc-end-bar__message a {
+  color: var(--docs-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  font-weight: 700;
+}
+
+.doc-end-bar__message a:hover {
+  color: var(--docs-primary);
+  text-decoration: underline;
+}
+
+/* Hash fill in the middle gap */
+.doc-end-bar__fill {
+  flex: 1;
+  align-self: center;
+  overflow: hidden;
+  font-family: 'Jetbrainsmono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--docs-border);
+  line-height: 1;
+  white-space: nowrap;
+  user-select: none;
+}
+
+/* Edit button — bordered pill at right end */
+.theme-edit-this-page {
+  font-family: 'Jetbrainsmono', monospace;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--docs-text-muted) !important;
+  text-decoration: none !important;
+  border: 1px solid var(--docs-border) !important;
+  padding: 0.375rem 0.75rem;
+  margin: 0.35rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  background: var(--ifm-background-color);
+  transition: color 0.15s ease, border-color 0.15s ease;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.theme-edit-this-page:hover {
+  color: var(--docs-primary) !important;
+  border-color: var(--docs-primary) !important;
+}
+
+.theme-edit-this-page svg {
+  width: 12px;
+  height: 12px;
 }
 
 /* ==========================================================================
@@ -1415,20 +2074,27 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   padding-left: 0;
 }
 
-.breadcrumbs__item:first-child .breadcrumbs__link {
+.breadcrumbs__item:first-child:last-child .breadcrumbs__link {
+  padding-left: 9px;
+}
+
+.breadcrumbs__item:first-child:not(:last-child) .breadcrumbs__link {
   padding-left: 0;
 }
 
 .breadcrumbs__link {
   color: var(--docs-text-muted);
+  cursor: pointer;
 }
 
 .breadcrumbs__link:hover {
   color: var(--docs-text);
+  background: none;
 }
 
 .breadcrumbs__item--active .breadcrumbs__link {
   color: var(--docs-text);
+  background: #eef0f3;
 }
 
 /* ==========================================================================
@@ -1439,9 +2105,27 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   border-radius: 0 !important;
 }
 
+/* L3 test - delete this */
+.menu__list .menu__list .menu__list > .menu__list-item > .menu__link,
+.menu__list .menu__list .menu__list > .menu__list-item > .menu__list-item-collapsible > .menu__link {
+  color: #737373 !important;
+}
+
+.menu__list .menu__list .menu__list > .menu__list-item > .menu__link.menu__link--active {
+  color: var(--docs-primary) !important;
+}
+
 /* ==========================================================================
    DARK MODE
    ========================================================================== */
+
+[data-theme='dark'] .navbar-icon--github {
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' fill='%239ca3af' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z'/%3E%3C/svg%3E");
+}
+
+[data-theme='dark'] .navbar-icon--discord {
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='%239ca3af' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z'/%3E%3C/svg%3E");
+}
 
 [data-theme='dark'] {
   --docs-primary: #5b8dee;

--- a/src/js/imageCollapse.js
+++ b/src/js/imageCollapse.js
@@ -1,0 +1,35 @@
+function initImageCollapse() {
+  const containers = document.querySelectorAll(
+    '.theme-doc-markdown p:has(> img), .theme-doc-markdown figure'
+  );
+
+  containers.forEach((container) => {
+    if (container.querySelector('.image-collapse-btn')) return;
+
+    const btn = document.createElement('button');
+    btn.className = 'image-collapse-btn';
+    btn.type = 'button';
+    btn.title = 'Minimize image';
+    btn.textContent = '\u2013';
+    btn.addEventListener('click', () => {
+      const collapsed = container.classList.toggle('image-collapsed');
+      btn.textContent = collapsed ? '+' : '\u2013';
+      btn.title = collapsed ? 'Expand image' : 'Minimize image';
+    });
+
+    container.appendChild(btn);
+  });
+}
+
+// Run on initial load
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initImageCollapse);
+} else {
+  initImageCollapse();
+}
+
+// Re-run on SPA navigation
+const observer = new MutationObserver(() => {
+  initImageCollapse();
+});
+observer.observe(document.body, {childList: true, subtree: true});

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -1,0 +1,5 @@
+import {type ReactNode} from 'react';
+
+export default function DocItemFooter(): ReactNode {
+  return null;
+}

--- a/src/theme/DocItem/Layout/EndBar.tsx
+++ b/src/theme/DocItem/Layout/EndBar.tsx
@@ -1,0 +1,50 @@
+import React, {type ReactNode} from 'react';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+
+function GitHubIcon(): ReactNode {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="12"
+      height="12"
+      fill="currentColor"
+      aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}
+
+export default function EndBar(): ReactNode {
+  const {metadata} = useDoc();
+  const {editUrl} = metadata;
+
+  return (
+    <div className="doc-end-bar-wrapper">
+      <div className="doc-end-bar">
+        <span className="doc-end-bar__message">
+          Questions? Just ask{' '}
+          <a
+            href="https://discord.com/invite/arrow"
+            target="_blank"
+            rel="noopener noreferrer">
+            Discord
+          </a>
+          {' '}&mdash; we're happy to help
+        </span>
+        <span className="doc-end-bar__fill" aria-hidden="true">
+          {'#'.repeat(80)}
+        </span>
+        {editUrl && (
+          <a
+            href={editUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="theme-edit-this-page">
+            <GitHubIcon />
+            Edit this page
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/theme/DocItem/Layout/MarkdownToggle.module.css
+++ b/src/theme/DocItem/Layout/MarkdownToggle.module.css
@@ -1,0 +1,112 @@
+.toggleButton {
+  background: none;
+  border: none;
+  color: var(--docs-text-muted);
+  padding: 0.25rem;
+  cursor: pointer;
+  transition: color 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+}
+
+.toggleButton:hover {
+  color: var(--docs-text);
+}
+
+.toggleButtonActive {
+  color: var(--docs-text);
+}
+
+.wrapper {
+  position: relative;
+}
+
+.rawHeader {
+  font-family: 'Jetbrainsmono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 1rem;
+  color: var(--docs-text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rawHeaderLinks {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.rawHeaderSep {
+  color: var(--docs-text-muted);
+  user-select: none;
+}
+
+.rawHeader a {
+  color: var(--docs-primary);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s ease;
+}
+
+.rawHeader a:hover {
+  border-bottom-color: var(--docs-primary);
+}
+
+.backButton {
+  font-family: 'Jetbrainsmono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: none;
+  border: none;
+  color: var(--docs-text-muted);
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  transition: color 0.15s ease;
+}
+
+.backButton:hover {
+  color: var(--docs-text);
+}
+
+.backButton svg {
+  width: 12px;
+  height: 12px;
+}
+
+.rawContent {
+  font-family: 'Jetbrainsmono', monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 1rem;
+  margin: 0;
+  background: #e4e4e4;
+  border: 1px solid var(--docs-border);
+  color: var(--docs-text);
+  overflow-x: auto;
+}
+
+.loading {
+  font-family: 'Jetbrainsmono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--docs-text-muted);
+  padding: 1rem 0;
+}
+
+.error {
+  font-family: 'Jetbrainsmono', monospace;
+  font-size: 11px;
+  color: #dc3545;
+  padding: 1rem 0;
+}

--- a/src/theme/DocItem/Layout/MarkdownToggle.tsx
+++ b/src/theme/DocItem/Layout/MarkdownToggle.tsx
@@ -1,0 +1,272 @@
+import React, {type ReactNode, useState, useLayoutEffect, useEffect, useCallback, useRef} from 'react';
+import {createPortal} from 'react-dom';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import styles from './MarkdownToggle.module.css';
+
+function editUrlToRawUrl(editUrl: string): string {
+  try {
+    const url = new URL(editUrl);
+    const parts = url.pathname.split('/');
+    const editIndex = parts.indexOf('edit');
+    if (editIndex === -1) return editUrl;
+    const org = parts[1];
+    const repo = parts[2];
+    const branch = parts[editIndex + 1];
+    const path = parts.slice(editIndex + 2).join('/');
+    return `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${path}`;
+  } catch {
+    return editUrl;
+  }
+}
+
+function MarkdownIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208 128" width="22" height="14" fill="currentColor" aria-hidden="true">
+      <rect width="198" height="118" x="5" y="5" rx="10" ry="10" stroke="currentColor" strokeWidth="10" fill="none"/>
+      <path d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39zm125 0l-30-33h20V30h20v35h20z"/>
+    </svg>
+  );
+}
+
+const BAR_WIDTH = 24;
+const BAR_FILL = 6;
+const BAR_STEP_MS = 30;
+const BAR_TOTAL_MS = (BAR_WIDTH + BAR_FILL) * BAR_STEP_MS; // ~900ms
+
+function AsciiProgressBar({label}: {label: string}) {
+  const [offset, setOffset] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setOffset((o) => (o + 1) % (BAR_WIDTH + BAR_FILL));
+    }, BAR_STEP_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const bar = Array.from({length: BAR_WIDTH}, (_, i) =>
+    i >= offset - BAR_FILL && i < offset ? '\u2588' : '\u2591'
+  ).join('');
+
+  return (
+    <div className={styles.loading}>
+      {label + '  [' + bar + ']'}
+    </div>
+  );
+}
+
+type ViewState = 'rendered' | 'raw' | 'transition-to-raw' | 'transition-to-rendered';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function MarkdownToggle({children}: Props): ReactNode {
+  const {metadata} = useDoc();
+  const editUrl = metadata.editUrl;
+
+  const [viewState, setViewState] = useState<ViewState>('rendered');
+  const [rawContent, setRawContent] = useState<string | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  const [rawPortalTarget, setRawPortalTarget] = useState<HTMLElement | null>(null);
+  const transitionTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const isRawVisible = viewState === 'raw' || viewState === 'transition-to-rendered';
+  const isTransitioning = viewState === 'transition-to-raw' || viewState === 'transition-to-rendered';
+
+  // Reset when navigating between docs
+  useEffect(() => {
+    setViewState('rendered');
+    setRawContent(null);
+    setFetchError(null);
+    if (transitionTimer.current) {
+      clearTimeout(transitionTimer.current);
+      transitionTimer.current = null;
+    }
+  }, [editUrl]);
+
+  // Single combined effect: h1 button, content visibility, raw portal
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+
+    const mdContainer = containerRef.current.querySelector('.theme-doc-markdown') as HTMLElement | null;
+    if (!mdContainer) return;
+
+    // --- 1. Always set up the h1 toggle button portal ---
+    const h1 = mdContainer.querySelector('h1') as HTMLElement | null;
+    if (h1) {
+      h1.style.display = 'flex';
+      h1.style.alignItems = 'center';
+      h1.style.gap = '0.75rem';
+
+      let btnTarget = h1.querySelector('.md-toggle-portal') as HTMLElement;
+      if (!btnTarget) {
+        btnTarget = document.createElement('span');
+        btnTarget.className = 'md-toggle-portal';
+        btnTarget.style.marginLeft = 'auto';
+        btnTarget.style.flexShrink = '0';
+        h1.appendChild(btnTarget);
+      }
+      setPortalTarget(btnTarget);
+    }
+
+    // Show raw mode for 'raw' and both transitions (so bar is visible in the raw layout)
+    const showRawLayout = viewState !== 'rendered';
+
+    if (showRawLayout) {
+      mdContainer.setAttribute('data-md-show-raw', '');
+
+      let rawPortal = mdContainer.querySelector('.md-raw-content-portal') as HTMLElement;
+      if (!rawPortal) {
+        rawPortal = document.createElement('div');
+        rawPortal.className = 'md-raw-content-portal';
+        mdContainer.appendChild(rawPortal);
+      }
+      setRawPortalTarget(rawPortal);
+    } else {
+      mdContainer.removeAttribute('data-md-show-raw');
+      const rawPortal = mdContainer.querySelector('.md-raw-content-portal');
+      rawPortal?.remove();
+      setRawPortalTarget(null);
+    }
+
+    return () => {
+      mdContainer.removeAttribute('data-md-show-raw');
+      const rawPortal = mdContainer.querySelector('.md-raw-content-portal');
+      rawPortal?.remove();
+
+      if (h1) {
+        h1.style.display = '';
+        h1.style.alignItems = '';
+        h1.style.gap = '';
+        const btnTarget = h1.querySelector('.md-toggle-portal');
+        btnTarget?.remove();
+      }
+    };
+  }, [viewState, editUrl]);
+
+  // Apply/remove grey background on the doc main container
+  useEffect(() => {
+    const el = document.querySelector<HTMLElement>('[class*="docMainContainer"]');
+    if (!el) return;
+    const showGrey = viewState !== 'rendered';
+    if (showGrey) {
+      el.style.backgroundColor = '#CCCCCC';
+    } else {
+      el.style.backgroundColor = '';
+    }
+    return () => {
+      el.style.backgroundColor = '';
+    };
+  }, [viewState]);
+
+  const handleToggle = useCallback(async () => {
+    if (isTransitioning) return;
+
+    if (transitionTimer.current) {
+      clearTimeout(transitionTimer.current);
+      transitionTimer.current = null;
+    }
+
+    if (viewState === 'raw') {
+      // --- Transition back to rendered ---
+      setViewState('transition-to-rendered');
+      transitionTimer.current = setTimeout(() => {
+        setViewState('rendered');
+        transitionTimer.current = null;
+      }, BAR_TOTAL_MS);
+      return;
+    }
+
+    // --- Transition to raw ---
+    setViewState('transition-to-raw');
+
+    // Fetch if needed (runs in parallel with transition)
+    let fetchPromise: Promise<void> | null = null;
+    if (!rawContent && editUrl) {
+      setFetchError(null);
+      fetchPromise = (async () => {
+        try {
+          const rawUrl = editUrlToRawUrl(editUrl);
+          const resp = await fetch(rawUrl);
+          if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
+          const text = await resp.text();
+          setRawContent(text);
+        } catch (e) {
+          setFetchError(`Failed to fetch source: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      })();
+    }
+
+    // Wait for both the transition bar and the fetch
+    const delay = new Promise<void>((r) => {
+      transitionTimer.current = setTimeout(r, BAR_TOTAL_MS);
+    });
+    await Promise.all([delay, fetchPromise].filter(Boolean));
+    transitionTimer.current = null;
+    setViewState('raw');
+  }, [viewState, isTransitioning, rawContent, editUrl]);
+
+  if (!editUrl) {
+    return <>{children}</>;
+  }
+
+  const toggleButton = (
+    <button
+      type="button"
+      className={`${styles.toggleButton} ${viewState !== 'rendered' ? styles.toggleButtonActive : ''}`}
+      onClick={handleToggle}
+      title={isRawVisible ? 'View rendered page' : 'View markdown source'}
+      disabled={isTransitioning}
+    >
+      <MarkdownIcon />
+    </button>
+  );
+
+  const transitionLabel = viewState === 'transition-to-raw' ? 'LOADING SOURCE' : 'RENDERING';
+
+  return (
+    <div className={styles.wrapper} ref={containerRef}>
+      {portalTarget && createPortal(toggleButton, portalTarget)}
+
+      {children}
+
+      {viewState !== 'rendered' && rawPortalTarget && createPortal(
+        <>
+          {isTransitioning ? (
+            <AsciiProgressBar label={transitionLabel} />
+          ) : (
+            <>
+              <div className={styles.rawHeader}>
+                <span className={styles.rawHeaderLinks}>
+                  <a href={editUrl} target="_blank" rel="noopener noreferrer">
+                    View on GitHub
+                  </a>
+                  <span className={styles.rawHeaderSep}>{'\u00b7'}</span>
+                  <a href={editUrl} target="_blank" rel="noopener noreferrer">
+                    Edit this page
+                  </a>
+                </span>
+                <button
+                  type="button"
+                  className={styles.backButton}
+                  onClick={handleToggle}
+                  disabled={isTransitioning}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+                    <path d="M10 2L4 8L10 14" strokeLinecap="square" strokeLinejoin="miter" />
+                  </svg>
+                  View Rendered
+                </button>
+              </div>
+              {fetchError && <div className={styles.error}>{fetchError}</div>}
+              {rawContent && <pre className={styles.rawContent}>{rawContent}</pre>}
+            </>
+          )}
+        </>,
+        rawPortalTarget
+      )}
+    </div>
+  );
+}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,17 @@
+import React, {type ReactNode} from 'react';
+import Layout from '@theme-original/DocItem/Layout';
+import type LayoutType from '@theme/DocItem/Layout';
+import type {WrapperProps} from '@docusaurus/types';
+import MarkdownToggle from './MarkdownToggle';
+import EndBar from './EndBar';
+
+type Props = WrapperProps<typeof LayoutType>;
+
+export default function LayoutWrapper(props: Props): ReactNode {
+  return (
+    <MarkdownToggle>
+      <Layout {...props} />
+      <EndBar />
+    </MarkdownToggle>
+  );
+}

--- a/src/theme/Navbar/DocsNavbar.module.css
+++ b/src/theme/Navbar/DocsNavbar.module.css
@@ -1,12 +1,24 @@
 .navbar {
-  position: sticky;
-  top: 0;
+  position: relative;
   z-index: 100;
-  background: #fafafa;
-  border-bottom: 1px solid #e5e7eb;
+  background: #0943bf;
+  border-bottom: none;
   height: 72px;
   display: flex;
   align-items: center;
+}
+
+.navbar::after {
+  content: '';
+  position: absolute;
+  bottom: 4px;
+  left: 0;
+  right: 0;
+  height: 8px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='8' viewBox='0 0 6 8' shape-rendering='crispEdges'%3E%3Crect x='4' y='0' width='2' height='2' fill='rgba(255,255,255,0.3)'/%3E%3Crect x='3' y='2' width='2' height='2' fill='rgba(255,255,255,0.3)'/%3E%3Crect x='2' y='4' width='2' height='2' fill='rgba(255,255,255,0.3)'/%3E%3Crect x='1' y='6' width='2' height='2' fill='rgba(255,255,255,0.3)'/%3E%3C/svg%3E");
+  background-repeat: repeat-x;
+  background-size: 6px 8px;
+  image-rendering: pixelated;
 }
 
 .navbarInner {
@@ -14,100 +26,61 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 0 1.5rem;
+  padding: 0 1.5rem 12px;
 }
 
 .logo {
   display: flex;
   align-items: center;
-  color: #0843BF;
+  color: #ffffff;
   text-decoration: none;
   transition: opacity 0.15s ease;
 }
 
 .logo:hover {
-  opacity: 0.7;
-  color: #0843BF;
+  opacity: 0.8;
+  color: #ffffff;
   text-decoration: none;
-}
-
-.navLinks {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-
-.navLink {
-  font-family: 'Departure Mono', 'JetBrains Mono', monospace;
-  font-size: 12px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: #6b7280;
-  padding: 0.5rem 1rem;
-  text-decoration: none;
-  transition: color 0.15s ease, background 0.15s ease;
-  border: 1px solid transparent;
-}
-
-.navLink:hover {
-  color: #1f2937;
-  background: rgba(0, 0, 0, 0.03);
-  text-decoration: none;
-}
-
-.navLink.active {
-  color: #0843BF;
-  background: rgba(8, 67, 191, 0.06);
-  border-color: rgba(8, 67, 191, 0.3);
 }
 
 .navActions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
-.navButton {
+.searchWrapper {
+  margin-right: 0.25rem;
+}
+
+.iconButton {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-family: 'Departure Mono', 'JetBrains Mono', monospace;
-  font-size: 11px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: #4b5563;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  color: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   background: transparent;
-  border: 1px solid #d1d5db;
-  padding: 0.5rem 0.875rem;
   text-decoration: none;
-  transition: all 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
-.navButton:hover {
-  background: #1f2937;
+.iconButton:hover {
   color: #ffffff;
-  border-color: #1f2937;
+  border-color: rgba(255, 255, 255, 0.5);
   text-decoration: none;
 }
 
-.navButton svg {
-  width: 14px;
-  height: 14px;
+.colorModeToggle {
+  display: flex;
+  align-items: center;
+  color: rgba(255, 255, 255, 0.7);
 }
 
 /* Mobile responsive */
 @media (max-width: 996px) {
-  .navLinks {
-    display: none;
-  }
-
-  .navButton span {
-    display: none;
-  }
-
-  .navButton {
-    padding: 0.5rem;
+  .searchWrapper {
+    margin-right: 0;
   }
 }

--- a/src/theme/Navbar/index.tsx
+++ b/src/theme/Navbar/index.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import NavbarOriginal from '@theme-original/Navbar';
 import Link from '@docusaurus/Link';
+import ColorModeToggle from '@theme/ColorModeToggle';
+import {useColorMode} from '@docusaurus/theme-common';
+import SearchBar from '@theme/SearchBar';
 import styles from './DocsNavbar.module.css';
 
 function ArrowLogo() {
@@ -18,7 +21,7 @@ function ArrowLogo() {
 
 function GitHubIcon() {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
       <path fill="currentColor" d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5c.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34c-.46-1.16-1.11-1.47-1.11-1.47c-.91-.62.07-.6.07-.6c1 .07 1.53 1.03 1.53 1.03c.87 1.52 2.34 1.07 2.91.83c.09-.65.35-1.09.63-1.34c-2.22-.25-4.55-1.11-4.55-4.92c0-1.11.38-2 1.03-2.71c-.1-.25-.45-1.29.1-2.64c0 0 .84-.27 2.75 1.02c.79-.22 1.65-.33 2.5-.33s1.71.11 2.5.33c1.91-1.29 2.75-1.02 2.75-1.02c.55 1.35.2 2.39.1 2.64c.65.71 1.03 1.6 1.03 2.71c0 3.82-2.34 4.66-4.57 4.91c.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2"></path>
     </svg>
   );
@@ -26,60 +29,51 @@ function GitHubIcon() {
 
 function DiscordIcon() {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
       <path fill="currentColor" d="M19.27 5.33C17.94 4.71 16.5 4.26 15 4a.1.1 0 0 0-.07.03c-.18.33-.39.76-.53 1.09a16.1 16.1 0 0 0-4.8 0c-.14-.34-.35-.76-.54-1.09c-.01-.02-.04-.03-.07-.03c-1.5.26-2.93.71-4.27 1.33c-.01 0-.02.01-.03.02c-2.72 4.07-3.47 8.03-3.1 11.95c0 .02.01.04.03.05c1.8 1.32 3.53 2.12 5.24 2.65c.03.01.06 0 .07-.02c.4-.55.76-1.13 1.07-1.74c.02-.04 0-.08-.04-.09c-.57-.22-1.11-.48-1.64-.78c-.04-.02-.04-.08-.01-.11c.11-.08.22-.17.33-.25c.02-.02.05-.02.07-.01c3.44 1.57 7.15 1.57 10.55 0c.02-.01.05-.01.07.01c.11.09.22.17.33.26c.04.03.04.09-.01.11c-.52.31-1.07.56-1.64.78c-.04.01-.05.06-.04.09c.32.61.68 1.19 1.07 1.74c.03.01.06.02.09.01c1.72-.53 3.45-1.33 5.25-2.65c.02-.01.03-.03.03-.05c.44-4.53-.73-8.46-3.1-11.95c-.01-.01-.02-.02-.04-.02M8.52 14.91c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.84 2.12-1.89 2.12m6.97 0c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.83 2.12-1.89 2.12"></path>
     </svg>
   );
 }
 
 function DocsNavbar() {
+  const {colorMode, setColorMode} = useColorMode();
+
   return (
     <nav className={styles.navbar}>
       <div className={styles.navbarInner}>
         {/* Logo */}
-        <Link to="/" className={styles.logo}>
+        <Link to="/docs/intro" className={styles.logo}>
           <ArrowLogo />
         </Link>
 
-        {/* Center Links */}
-        <div className={styles.navLinks}>
-          <Link to="/" className={styles.navLink}>
-            Home
-          </Link>
-          <Link to="/docs" className={`${styles.navLink} ${styles.active}`}>
-            Docs
-          </Link>
-          <Link to="/engineering" className={styles.navLink}>
-            Engineering
-          </Link>
-          <Link to="/community" className={styles.navLink}>
-            Community
-          </Link>
-          <Link to="/dao" className={styles.navLink}>
-            DAO
-          </Link>
-        </div>
-
         {/* Right Actions */}
         <div className={styles.navActions}>
+          <div className={styles.searchWrapper}>
+            <SearchBar />
+          </div>
           <a
             href="https://github.com/Arrow-air"
             target="_blank"
             rel="noopener noreferrer"
-            className={styles.navButton}
+            className={styles.iconButton}
+            aria-label="GitHub"
           >
             <GitHubIcon />
-            <span>GitHub</span>
           </a>
           <a
             href="https://discord.com/invite/arrow"
             target="_blank"
             rel="noopener noreferrer"
-            className={styles.navButton}
+            className={styles.iconButton}
+            aria-label="Discord"
           >
             <DiscordIcon />
-            <span>Discord</span>
           </a>
+          <ColorModeToggle
+            className={styles.colorModeToggle}
+            value={colorMode}
+            onChange={setColorMode}
+          />
         </div>
       </div>
     </nav>


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                   
  - Custom blue navbar with pixel slash decoration, GitHub/Discord/color mode icons, and retro-styled CLI search bar                                                                           
  - Retro end-of-content bar with Discord CTA, hash fill pattern, and GitHub edit link                                                                                                       
  - Sidebar styling: non-collapsible top-level categories, section spacing, pixelated collapse/expand buttons                                                                                  
  - OS window-style admonition title bars and matching code block styling                                                                                                                      
  - Subtle link underlines with external link arrow orphan fix
  - `hide_table_of_contents` on pages without h2/h3 headings
  - Color mode config (light default, no OS preference)
  - Fix import script to preserve sidebar category settings
  - New DocItem Layout wrapper with MarkdownToggle and EndBar components