### PR TITLE
Update engineering page copy

### DIFF
--- a/templates/pages/engineering.body.html
+++ b/templates/pages/engineering.body.html
@@ -15,38 +15,47 @@
         <p>This is how we do it.</p>
         <hr>
         <h2>MEETINGS</h2>
-        <h3>WEEKLY ENGINEERING SYNC</h3>
-        <p><strong>Tuesdays, 1800 UTC</strong><br>
-        Voice chat on Discord. Project updates, technical discussions, and problem solving. Casual but focused. Recordings posted for those who can't make it.</p>
+        <h3>DAILY ENGINEERING CALLS</h3>
+        <p><strong>Every day on Discord</strong><br>
+        Voice chat. What you're working on, what's blocking you, what needs attention. Sometimes it's a quick sync, sometimes we dig into a problem for an hour. The agenda is whatever matters most that day.</p>
         <h3>DESIGN REVIEWS</h3>
-        <p>Scheduled as needed. We jump into VR or screenshare to review CAD models together. It's surprisingly effective—better than looking at a screen alone.</p>
+        <p>Scheduled when a design needs focused attention. We screenshare CAD models, walk through changes, and hash out decisions together. These get planned ahead on the daily calls.</p>
         <h3>ASYNC EVERYTHING ELSE</h3>
         <p>Most communication happens in Discord text channels. Work on your own schedule. Post updates, ask questions, share progress. We're spread across timezones so async is the default.</p>
         <p><a href="https://discord.com/invite/arrow" target="_blank">→ Join our Discord</a></p>
         <hr>
         <h2>SOFTWARE &amp; TOOLS</h2>
         <h3>CAD</h3>
-        <p><strong>Fusion 360</strong> or <strong>OnShape</strong><br>
-        Both have free tiers. Files live on GitHub. We can all open, fork, and improve each other's designs.</p>
+        <p><strong>build123d</strong> — Parametric CAD in Python<br>
+        Main assemblies live on GitHub as code. Version controlled, forkable, reviewable—just like software. Need to contribute a part from Fusion, SolidWorks, or whatever you use? Export a STEP file and submit a PR.</p>
         <h3>ELECTRONICS</h3>
-        <p><strong>KiCad</strong> for circuit boards<br>
-        <strong>PlatformIO</strong> for firmware<br>
-        All open source, all on GitHub.</p>
+        <p><strong>KiCad</strong> for circuit board design<br>
+        Open source, on GitHub. Same workflow as everything else.</p>
         <h3>SIMULATION</h3>
-        <p><strong>Fusion 360 FEA</strong> for structural analysis<br>
-        <strong>XFLR5</strong> for aerodynamics<br>
-        <strong>Custom Python scripts</strong> for flight dynamics</p>
-        <p>We simulate heavily before building. Saves time and money.</p>
+        <p><strong>Custom Python scripts</strong> for flight dynamics and analysis<br>
+        We simulate before we build. Saves time, money, and aircraft.</p>
         <h3>COLLABORATION</h3>
-        <p><strong>GitHub</strong> — All our designs, code, and docs<br>
-        <strong>Discord</strong> — Daily communication<br>
-        <strong>Notion</strong> — Long-form documentation<br>
-        <strong>Spatial/VR tools</strong> — 3D design reviews</p>
+        <p><strong>GitHub</strong> — Designs, code, docs, and meeting notes<br>
+        <strong>Discord</strong> — Daily communication</p>
+        <p>That's it. We keep the toolchain simple.</p>
         <p><a href="https://github.com/Arrow-air" target="_blank">→ See our GitHub</a> | <a href="/docs/">→ Read the docs</a></p>
+        <hr>
+        <h2>BUILDING HARDWARE</h2>
+        <h3>PROTOTYPE BUILDS</h3>
+        <p>When a design is ready, we coordinate a build. Sometimes in person at a meetup. Sometimes distributed—multiple people building the same design in their own workshops and streaming it.</p>
+        <h3>YOUR OWN BUILD</h3>
+        <p>You can manufacture any of our designs locally. Follow the instructions, document your results, and share what you learn. Improvements flow back to the community via pull requests.</p>
+        <p><a href="#">→ Assembly instructions</a> | <a href="#">→ Bill of materials</a></p>
+        <hr>
+        <h2>TESTING</h2>
+        <p>We test everything before it flies.</p>
+        <p><strong>Simulation</strong> → <strong>Bench testing</strong> → <strong>Ground testing</strong> → <strong>Flight testing</strong></p>
+        <p>Flight tests are live-streamed on Discord. The whole community watches, learns, and debugs together. Between flights, community members test parts in their own workshops and feed results back to improve the designs.</p>
+        <p><a href="#">→ Safety protocols</a> | <a href="#">→ Test procedures</a></p>
         <hr>
         <h2>HOW TO CONTRIBUTE</h2>
         <h3>1. PICK SOMETHING</h3>
-        <p>Browse open issues on GitHub. Look for tags like <code>good-first-issue</code> or <code>help-wanted</code>. Or propose something new.</p>
+        <p>Browse open issues on GitHub. Look for tags like <code>good-first-issue</code> or <code>help-wanted</code>. Or propose something new—visit our <a href="dao.html">DAO forum</a> to pitch a project as a grant or bounty.</p>
         <h3>2. FORK AND BUILD</h3>
         <p>Clone the repo. Make your changes. Test them. CAD, code, documentation—it all works the same way.</p>
         <h3>3. SUBMIT A PULL REQUEST</h3>
@@ -55,19 +64,6 @@
         <p>Community reviews your work. Discussion happens in the PR. Once approved, it merges into the main project.</p>
         <p>That's it. Same workflow as software, but for aircraft.</p>
         <p><a href="#">→ Contribution guide</a> | <a href="#">→ Design standards</a></p>
-        <hr>
-        <h2>TESTING</h2>
-        <p>We test everything before it flies.</p>
-        <p><strong>Simulation</strong> → <strong>Bench testing</strong> → <strong>Ground testing</strong> → <strong>Flight testing</strong></p>
-        <p>Flight tests are live-streamed when possible. The whole community watches and learns together.</p>
-        <p><a href="#">→ Safety protocols</a> | <a href="#">→ Test procedures</a></p>
-        <hr>
-        <h2>BUILDING HARDWARE</h2>
-        <h3>PROTOTYPE BUILDS</h3>
-        <p>When a design is ready, we coordinate a build. Sometimes in person at a meetup. Sometimes distributed—multiple people building the same design in their own workshops and streaming it.</p>
-        <h3>YOUR OWN BUILD</h3>
-        <p>You can manufacture any of our designs locally. Follow the instructions, document your results, and share what you learn. Improvements flow back to the community via pull requests.</p>
-        <p><a href="#">→ Assembly instructions</a> | <a href="#">→ Bill of materials</a></p>
         <hr>
         <h2>QUESTIONS?</h2>
         <p><strong>“Do I need to be an aerospace engineer?”</strong><br>


### PR DESCRIPTION
## Changes

Updates the engineering page copy to better reflect how Arrow actually works today.

### Meetings
- Replaced weekly engineering sync with **daily engineering calls** (which is what we actually do)
- Design reviews positioned as scheduled-as-needed, planned on the daily calls
- Async section unchanged

### Software & Tools
- **build123d** replaces Fusion 360/OnShape as the primary CAD tool
- Added STEP file workflow for contributors using other CAD tools
- Dropped PlatformIO, XFLR5, Notion, and Spatial/VR tools
- GitHub now covers docs + meeting notes

### How to Contribute
- Added link to DAO forum for proposing grants/bounties

### Testing
- Added community workshop testing feedback loop
- Livestreams now reference Discord specifically

### Section Reorder
Meetings → Software & Tools → Building Hardware → Testing → How to Contribute → FAQ → CTA

(Was: Meetings → Tools → Contribute → Testing → Hardware)

---

**⚠️ Placeholder links to resolve before merge:**
- Contribution guide
- Design standards
- Safety protocols
- Test procedures
- Assembly instructions
- Bill of materials
- Book a Call (no Calendly set up yet — create or remove?)
- Discord invite link (`discord.com/invite/arrow`) — verify still valid

Would love community input on what docs to link for each of these 👆