### PR TITLE
Add dark mode support for docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "clsx": "^2.1.1",
         "gts": "^3.1.0",
         "lottie-web": "^5.13.0",
+        "playwright": "^1.58.2",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -14622,6 +14623,50 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "clsx": "^2.1.1",
         "gts": "^3.1.0",
         "lottie-web": "^5.13.0",
-        "playwright": "^1.58.2",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -24,6 +23,7 @@
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.7.0",
+        "playwright": "^1.58.2",
         "typescript": "^5.7.3"
       }
     },
@@ -14629,6 +14629,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -14647,6 +14648,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14659,6 +14661,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "clsx": "^2.1.1",
     "gts": "^3.1.0",
     "lottie-web": "^5.13.0",
-    "playwright": "^1.58.2",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -35,6 +34,7 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.7.0",
+    "playwright": "^1.58.2",
     "typescript": "^5.7.3"
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "clsx": "^2.1.1",
     "gts": "^3.1.0",
     "lottie-web": "^5.13.0",
+    "playwright": "^1.58.2",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/CLA/styles.css
+++ b/src/components/CLA/styles.css
@@ -385,3 +385,22 @@
   widows: 2;
   text-align: left
 }
+
+/* Dark mode */
+[data-theme='dark'] .cla-text p,
+[data-theme='dark'] .cla-text li,
+[data-theme='dark'] .cla-text .c1,
+[data-theme='dark'] .cla-text h1,
+[data-theme='dark'] .cla-text h2,
+[data-theme='dark'] .cla-text h3,
+[data-theme='dark'] .cla-text h4,
+[data-theme='dark'] .cla-text h5,
+[data-theme='dark'] .cla-text h6,
+[data-theme='dark'] .cla-text .title {
+  color: #d1d5db;
+}
+
+[data-theme='dark'] .cla-text .c11,
+[data-theme='dark'] .cla-text .c9 {
+  background-color: transparent;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -776,7 +776,8 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   display: block;
   width: 12px;
   height: 12px;
-  background-color: currentColor;
+  background: currentColor;
+  filter: none !important;
   opacity: 0.6;
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none'%3E%3Cpath d='M5 2L11 8L5 14' stroke='black' stroke-width='2' stroke-linecap='square' stroke-linejoin='miter' fill='none'/%3E%3C/svg%3E");
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none'%3E%3Cpath d='M5 2L11 8L5 14' stroke='black' stroke-width='2' stroke-linecap='square' stroke-linejoin='miter' fill='none'/%3E%3C/svg%3E");
@@ -2136,6 +2137,10 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   --docs-border: #374151;
   --docs-bg: #111827;
   --docs-bg-subtle: #1f2937;
+  --docs-bg-elevated: #243046;
+  --docs-shadow: rgba(0, 0, 0, 0.3);
+
+  --bs-dark: #f3f4f6;
 
   --ifm-color-primary: #5b8dee;
   --ifm-color-primary-dark: #3d79ea;
@@ -2144,4 +2149,177 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   --ifm-color-primary-light: #79a1f2;
   --ifm-color-primary-lighter: #88abf4;
   --ifm-color-primary-lightest: #b5cbf9;
+}
+
+/* --- Dark mode: Sidebar --- */
+[data-theme='dark'] .theme-doc-sidebar-container {
+  border-right-color: var(--docs-border);
+}
+
+[data-theme='dark'] .menu__list > .menu__list-item > .menu__list-item-collapsible > .menu__link,
+[data-theme='dark'] .theme-doc-sidebar-menu > .menu__list-item > .menu__list-item-collapsible > .menu__link,
+[data-theme='dark'] .theme-doc-sidebar-menu > li > .menu__list-item-collapsible > .menu__link,
+[data-theme='dark'] ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link {
+  color: var(--docs-text) !important;
+}
+
+[data-theme='dark'] .menu__list > .menu__list-item > .menu__list-item-collapsible > .menu__link::before,
+[data-theme='dark'] .theme-doc-sidebar-menu > .menu__list-item > .menu__list-item-collapsible > .menu__link::before,
+[data-theme='dark'] .theme-doc-sidebar-menu > li > .menu__list-item-collapsible > .menu__link::before,
+[data-theme='dark'] ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::before {
+  background-color: var(--docs-text);
+}
+
+[data-theme='dark'] .menu__list-item-collapsible.menu__list-item-collapsible--active {
+  border-right-color: rgba(255, 255, 255, 0.25);
+}
+
+[data-theme='dark'] .menu__list .menu__list .menu__list > .menu__list-item > .menu__link,
+[data-theme='dark'] .menu__list .menu__list .menu__list > .menu__list-item > .menu__list-item-collapsible > .menu__link {
+  color: var(--docs-text-muted) !important;
+}
+
+/* --- Dark mode: Sidebar chevron caret --- */
+[data-theme='dark'] .menu__caret::before {
+  opacity: 1;
+  background-color: var(--docs-text-muted);
+}
+
+[data-theme='dark'] .menu__caret:hover::before {
+  background-color: var(--docs-text);
+}
+
+/* --- Dark mode: Typography --- */
+[data-theme='dark'] .theme-doc-markdown h2 {
+  border-bottom-color: rgba(91, 141, 238, 0.3);
+}
+
+/* --- Dark mode: Inline code --- */
+[data-theme='dark'] .theme-doc-markdown code {
+  background: var(--docs-bg-subtle);
+  border-color: var(--docs-border);
+}
+
+/* --- Dark mode: Code blocks --- */
+[data-theme='dark'] .theme-doc-markdown pre {
+  background: var(--docs-bg-subtle) !important;
+  border-color: var(--docs-border);
+  box-shadow: 4px 4px 0 0 var(--docs-shadow);
+}
+
+[data-theme='dark'] .theme-doc-markdown pre code .token-line::before {
+  color: #4b5563;
+  border-right-color: var(--docs-border);
+}
+
+[data-theme='dark'] .theme-doc-markdown pre code .token-line:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+[data-theme='dark'] .theme-doc-markdown .docusaurus-highlight-code-line,
+[data-theme='dark'] .theme-doc-markdown pre code .token-line.highlight-line {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+[data-theme='dark'] [class*="codeBlockContainer"] {
+  background: var(--docs-bg-subtle);
+}
+
+[data-theme='dark'] [class*="codeBlockTitle"] {
+  background: var(--docs-border);
+  border-color: var(--docs-border);
+  border-bottom-color: var(--docs-border);
+  color: #ffffff;
+}
+
+/* --- Dark mode: Tables --- */
+[data-theme='dark'] .theme-doc-markdown th {
+  background: var(--docs-bg-elevated);
+  color: var(--docs-primary);
+}
+
+/* --- Dark mode: Images & Figures --- */
+[data-theme='dark'] .theme-doc-markdown img {
+  border-color: var(--docs-border);
+  box-shadow: 4px 4px 0 0 var(--docs-shadow);
+}
+
+[data-theme='dark'] .theme-doc-markdown p:has(> img),
+[data-theme='dark'] .theme-doc-markdown figure {
+  border-color: var(--docs-border);
+  box-shadow: 4px 4px 0 0 var(--docs-shadow);
+  background:
+    linear-gradient(var(--docs-bg-subtle), var(--docs-bg-subtle)) top left / 100% calc(100% - 0.6rem) no-repeat,
+    repeating-linear-gradient(
+      -45deg,
+      var(--docs-border) 0px,
+      var(--docs-border) 1px,
+      var(--docs-bg-subtle) 1px,
+      var(--docs-bg-subtle) 5px
+    );
+}
+
+[data-theme='dark'] .theme-doc-markdown p:has(> img)::before,
+[data-theme='dark'] .theme-doc-markdown figure::before {
+  background: var(--docs-bg-elevated);
+  border-bottom-color: var(--docs-border);
+  color: var(--docs-text-muted);
+}
+
+[data-theme='dark'] .image-collapsed {
+  background: var(--docs-bg-subtle) !important;
+}
+
+[data-theme='dark'] .theme-doc-markdown figcaption {
+  border-top-color: var(--docs-border);
+}
+
+/* --- Dark mode: Admonitions --- */
+[data-theme='dark'] .alert {
+  --adm-bg: #1a1f2e;
+  --adm-border: #d1d5db;
+  box-shadow: 4px 4px 0 0 var(--docs-shadow);
+}
+
+[data-theme='dark'] .alert--note {
+  --adm-bg: #1c2030;
+  --adm-border: #6b7280;
+}
+
+[data-theme='dark'] .alert--tip {
+  --adm-bg: #162016;
+  --adm-border: #4ade80;
+}
+
+[data-theme='dark'] .alert--info {
+  --adm-bg: #111d33;
+  --adm-border: #60a5fa;
+}
+
+[data-theme='dark'] .alert--warning {
+  --adm-bg: #271e0c;
+  --adm-border: #fbbf24;
+}
+
+[data-theme='dark'] .alert--danger {
+  --adm-bg: #2a1215;
+  --adm-border: #f87171;
+}
+
+[data-theme='dark'] .alert [class*="admonitionContent"] code {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* --- Dark mode: Breadcrumbs --- */
+[data-theme='dark'] .breadcrumbs__item--active .breadcrumbs__link {
+  background: var(--docs-bg-subtle);
+}
+
+/* --- Dark mode: TOC --- */
+[data-theme='dark'] .table-of-contents__link--active {
+  color: var(--docs-primary);
+}
+
+[data-theme='dark'] .table-of-contents__link--active::before {
+  background: var(--docs-primary);
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -170,14 +170,8 @@ nav[class*="navbar"] > [class*="navbarInner"] {
 }
 
 /* Keyboard shortcut hints */
-.navbar__search .searchHintContainer .searchHint {
-  font-family: 'Jetbrainsmono', monospace !important;
-  font-size: 9px !important;
-  color: rgba(255, 255, 255, 0.4) !important;
-  background: rgba(255, 255, 255, 0.1) !important;
-  border: 1px solid rgba(255, 255, 255, 0.2) !important;
-  box-shadow: none !important;
-  border-radius: 0 !important;
+[class*="searchHint"] {
+  color: #062d8a !important;
 }
 
 .footer__logo {
@@ -198,7 +192,6 @@ nav[class*="navbar"] > [class*="navbarInner"] {
 }
 
 .card {
-    border-radius: 0rem;
     border: none;
     background-color: transparent;
     box-shadow: none;
@@ -582,26 +575,51 @@ h1, .h1 {
   line-height: 1;
   position: relative;
   border: 2px solid;
-  padding: 5px;
+  padding: 5px 10px;
   margin-top: 13px;
   border-radius: 5px;
   transition: background .3s;
   color: rgb(27, 20, 100);
   background: rgb(200, 200, 229);
   border-color: rgb(200, 200, 229);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .sign-cla button span {
-    margin-left: 5px;
-    position: relative;
-    top: 2px;
-    padding-bottom: 10px
+    margin: 0;
+    position: static;
 }
 .sign-cla button:hover,
 .sign-cla button:focus {
     background: darkgrey;
     border-color: darkgrey;
  }
+
+/* CLA — dark mode */
+[data-theme='dark'] .sign-cla .cla-scroll-box {
+  background: #1f2937;
+  border-color: #374151;
+  color: #d1d5db;
+}
+
+[data-theme='dark'] .sign-cla input[type=checkbox] {
+  background-color: #1f2937;
+  border-color: #6b7280;
+}
+
+[data-theme='dark'] .sign-cla button {
+  color: #ffffff;
+  background: #0A43BF;
+  border-color: #0A43BF;
+}
+
+[data-theme='dark'] .sign-cla button:hover,
+[data-theme='dark'] .sign-cla button:focus {
+  background: #073aab;
+  border-color: #073aab;
+}
 
 /* ==========================================================================
    DOCS STYLING
@@ -621,7 +639,7 @@ h1, .h1 {
   --docs-bg-subtle: #f9fafb;
 
   /* Content width */
-  --docs-content-max-width: 800px;
+  --docs-content-max-width: 860px;
 
   /* Docusaurus overrides */
   --ifm-color-primary: #0843BF;
@@ -632,7 +650,7 @@ h1, .h1 {
   --ifm-color-primary-lighter: #0a50dd;
   --ifm-color-primary-lightest: #1560f0;
   --ifm-font-family-base: 'Neue Haas Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  --ifm-font-size-base: 15px;
+  --ifm-font-size-base: 16px;
   --ifm-line-height-base: 1.6;
   --ifm-menu-color: var(--docs-text-secondary);
   --ifm-menu-color-active: var(--docs-primary);
@@ -872,7 +890,11 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
    GLOBAL RESETS - No rounded corners
    ========================================================================== */
 
-*, *::before, *::after {
+.theme-doc-sidebar-container *,
+.theme-doc-markdown *,
+[class*="docMainContainer"] *,
+.alert *,
+.pagination-nav * {
   border-radius: 0 !important;
 }
 
@@ -903,7 +925,7 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 /* Main docs container - add padding and constrain width */
 .theme-doc-markdown {
   font-family: 'Neue Haas Grotesk', sans-serif;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 1.6;
   color: var(--docs-text-secondary);
   max-width: var(--docs-content-max-width);
@@ -1024,7 +1046,7 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 .theme-doc-markdown p {
   margin: 0 0 0.875rem 0;
   color: var(--docs-text-secondary);
-  font-size: 1.1rem;
+  font-size: 1rem;
   line-height: 1.65;
 }
 
@@ -1309,12 +1331,13 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 .alert {
   --adm-bg: #f0efe8;
   --adm-border: #1f2937;
+  --adm-text: var(--adm-border);
   background: var(--adm-bg);
   border: 2px solid var(--adm-border);
   box-shadow: 4px 4px 0 0 rgba(0, 0, 0, 0.12);
   padding: 0;
   margin: 2.5rem 0;
-  color: var(--adm-border);
+  color: var(--adm-text);
   font-size: 14px;
   line-height: 1.6;
 }
@@ -1367,18 +1390,17 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 
 .alert [class*="admonitionHeading"] svg {
   fill: #ffffff;
-  stroke: #ffffff;
   color: #ffffff;
 }
 
 /* Content area */
 .alert [class*="admonitionContent"] {
   padding: 0.75rem 1rem;
-  color: var(--adm-border);
+  color: var(--adm-text);
 }
 
 .alert [class*="admonitionContent"] p {
-  color: var(--adm-border);
+  color: var(--adm-text);
 }
 
 .alert [class*="admonitionContent"] p:last-child {
@@ -1386,14 +1408,14 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 }
 
 .alert [class*="admonitionContent"] a {
-  color: var(--adm-border);
-  border-bottom-color: var(--adm-border);
+  color: var(--adm-text);
+  border-bottom-color: var(--adm-text);
 }
 
 .alert [class*="admonitionContent"] code {
   background: rgba(0, 0, 0, 0.06);
   border: 1px solid var(--adm-border);
-  color: var(--adm-border);
+  color: var(--adm-text);
 }
 
 /* --- Type colors --- */
@@ -1458,8 +1480,8 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   margin-top: 0;
 }
 
-.theme-doc-markdown p:has(> img),
-.theme-doc-markdown figure {
+.theme-doc-markdown p:has(> img):not(td p),
+.theme-doc-markdown figure:not(td figure) {
   position: relative;
   margin: 1.5rem 0;
   border: 1px solid #D5D8DC;
@@ -1476,8 +1498,8 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
     );
 }
 
-.theme-doc-markdown p:has(> img)::before,
-.theme-doc-markdown figure::before {
+.theme-doc-markdown p:has(> img):not(td p)::before,
+.theme-doc-markdown figure:not(td figure)::before {
   content: 'IMAGE';
   display: block;
   font-family: 'Departure Mono', 'Jetbrainsmono', monospace;
@@ -1791,7 +1813,7 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 .doc-end-bar-wrapper {
   max-width: var(--docs-content-max-width);
   margin: 1.5rem auto 0;
-  padding: 0 30px;
+  padding: 0 var(--ifm-spacing-horizontal);
 }
 
 .doc-end-bar {
@@ -2057,10 +2079,17 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 
 /* Breadcrumbs wrapper - match content layout */
 [class*="breadcrumbsContainer"] {
-  max-width: 800px;
+  max-width: var(--docs-content-max-width);
   margin: 0 auto;
   padding: 0 2rem;
   width: 100%;
+}
+
+/* Generated index pages - breadcrumbs match full-width card layout */
+[class*="generatedIndexPage"] [class*="breadcrumbsContainer"] {
+  max-width: none;
+  margin: 0;
+  padding: 0;
 }
 
 .breadcrumbs {
@@ -2102,14 +2131,10 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
    SIDEBAR REFINEMENTS
    ========================================================================== */
 
-.menu__link {
-  border-radius: 0 !important;
-}
-
-/* L3 test - delete this */
+/* L3 sidebar items — use muted text for tertiary nav */
 .menu__list .menu__list .menu__list > .menu__list-item > .menu__link,
 .menu__list .menu__list .menu__list > .menu__list-item > .menu__list-item-collapsible > .menu__link {
-  color: #737373 !important;
+  color: var(--docs-text-muted) !important;
 }
 
 .menu__list .menu__list .menu__list > .menu__list-item > .menu__link.menu__link--active {
@@ -2244,8 +2269,8 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   box-shadow: 4px 4px 0 0 var(--docs-shadow);
 }
 
-[data-theme='dark'] .theme-doc-markdown p:has(> img),
-[data-theme='dark'] .theme-doc-markdown figure {
+[data-theme='dark'] .theme-doc-markdown p:has(> img):not(td p),
+[data-theme='dark'] .theme-doc-markdown figure:not(td figure) {
   border-color: var(--docs-border);
   box-shadow: 4px 4px 0 0 var(--docs-shadow);
   background:
@@ -2259,8 +2284,8 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
     );
 }
 
-[data-theme='dark'] .theme-doc-markdown p:has(> img)::before,
-[data-theme='dark'] .theme-doc-markdown figure::before {
+[data-theme='dark'] .theme-doc-markdown p:has(> img):not(td p)::before,
+[data-theme='dark'] .theme-doc-markdown figure:not(td figure)::before {
   background: var(--docs-bg-elevated);
   border-bottom-color: var(--docs-border);
   color: var(--docs-text-muted);
@@ -2277,33 +2302,39 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 /* --- Dark mode: Admonitions --- */
 [data-theme='dark'] .alert {
   --adm-bg: #1a1f2e;
-  --adm-border: #d1d5db;
+  --adm-border: #0A43BF;
+  --adm-text: #d1d5db;
   box-shadow: 4px 4px 0 0 var(--docs-shadow);
 }
 
 [data-theme='dark'] .alert--note {
-  --adm-bg: #1c2030;
-  --adm-border: #6b7280;
+  --adm-bg: #0c1a35;
+  --adm-border: #4a6fa5;
+  --adm-text: #e5e7eb;
 }
 
 [data-theme='dark'] .alert--tip {
-  --adm-bg: #162016;
-  --adm-border: #4ade80;
+  --adm-bg: #0c1a35;
+  --adm-border: #2d7a4a;
+  --adm-text: #d1fae5;
 }
 
 [data-theme='dark'] .alert--info {
-  --adm-bg: #111d33;
-  --adm-border: #60a5fa;
+  --adm-bg: #0c1a35;
+  --adm-border: #1e3a6e;
+  --adm-text: #93c5fd;
 }
 
 [data-theme='dark'] .alert--warning {
-  --adm-bg: #271e0c;
-  --adm-border: #fbbf24;
+  --adm-bg: #1a1508;
+  --adm-border: #7a5a10;
+  --adm-text: #fcd34d;
 }
 
 [data-theme='dark'] .alert--danger {
-  --adm-bg: #2a1215;
-  --adm-border: #f87171;
+  --adm-bg: #1f0f0f;
+  --adm-border: #8b2020;
+  --adm-text: #fca5a5;
 }
 
 [data-theme='dark'] .alert [class*="admonitionContent"] code {
@@ -2322,4 +2353,129 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 
 [data-theme='dark'] .table-of-contents__link--active::before {
   background: var(--docs-primary);
+}
+
+/* --- Dark mode: H1 title underline --- */
+[data-theme='dark'] .theme-doc-markdown h1 {
+  border-bottom-color: rgba(255, 255, 255, 0.25);
+}
+
+/* --- Dark mode: Blockquotes --- */
+[data-theme='dark'] .theme-doc-markdown blockquote {
+  border-left-color: var(--docs-border);
+  background: var(--docs-bg-subtle);
+  color: var(--docs-text-secondary);
+}
+
+/* --- Dark mode: Pagination nav --- */
+[data-theme='dark'] .pagination-nav__link {
+  border-color: var(--docs-primary);
+}
+
+[data-theme='dark'] .pagination-nav__link:hover {
+  background-color: rgba(91, 141, 238, 0.08);
+}
+
+/* --- Dark mode: End bar (Discord CTA + Edit button) --- */
+[data-theme='dark'] .doc-end-bar {
+  border-color: var(--docs-border);
+  background: var(--docs-bg);
+}
+
+[data-theme='dark'] .doc-end-bar__fill {
+  color: var(--docs-border);
+}
+
+[data-theme='dark'] .theme-edit-this-page {
+  border-color: var(--docs-border) !important;
+  background: var(--docs-bg);
+}
+
+/* --- Dark mode: Details/accordion --- */
+[data-theme='dark'] .theme-doc-markdown summary {
+  color: var(--docs-text);
+}
+
+[data-theme='dark'] .theme-doc-markdown summary::before {
+  color: var(--docs-text-muted);
+}
+
+[data-theme='dark'] .theme-doc-markdown summary:hover {
+  color: var(--docs-primary);
+}
+
+[data-theme='dark'] .theme-doc-markdown summary:hover::before {
+  color: var(--docs-primary);
+}
+
+/* --- Dark mode: Breadcrumb separator --- */
+[data-theme='dark'] .breadcrumbs__item--active .breadcrumbs__link {
+  color: var(--docs-text);
+}
+
+[data-theme='dark'] .breadcrumbs__link {
+  color: var(--docs-text-muted);
+}
+
+[data-theme='dark'] .breadcrumbs__link:hover {
+  color: var(--docs-text);
+}
+
+/* --- Dark mode: Sidebar collapse/expand buttons --- */
+[data-theme='dark'] [class*="collapseSidebarButton"] {
+  border-color: var(--docs-border) !important;
+}
+
+[data-theme='dark'] [class*="collapseSidebarButton"]:hover,
+[data-theme='dark'] [class*="collapseSidebarButton"]:focus {
+  background-color: var(--docs-bg-subtle) !important;
+}
+
+[data-theme='dark'] [class*="expandButton"]:hover,
+[data-theme='dark'] [class*="expandButton"]:focus {
+  background-color: var(--docs-bg-subtle) !important;
+}
+
+/* --- Dark mode: Horizontal rules --- */
+[data-theme='dark'] .theme-doc-markdown hr {
+  border-top-color: var(--docs-border);
+}
+
+/* ==========================================================================
+   DOCSEARCH NAVBAR OVERRIDES
+   ========================================================================== */
+
+/* Search bar input */
+.navbar__search-input {
+  background-color: transparent !important;
+  border: 1px solid rgba(255, 255, 255, 0.2) !important;
+  border-radius: 0 !important;
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+.navbar__search-input::placeholder {
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.navbar__search-input:focus {
+  border-color: rgba(255, 255, 255, 0.5) !important;
+  outline: none !important;
+}
+
+/* Search keyboard shortcut hints */
+kbd[class*="searchHint"] {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  border: 1px solid rgba(255, 255, 255, 0.3) !important;
+  border-bottom-width: 2px !important;
+  border-radius: 3px !important;
+  color: rgba(255, 255, 255, 0.6) !important;
+  box-shadow: none !important;
+}
+
+[data-theme='dark'] kbd[class*="searchHint"] {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  border: 1px solid rgba(255, 255, 255, 0.3) !important;
+  border-bottom-width: 2px !important;
+  color: rgba(255, 255, 255, 0.6) !important;
+  box-shadow: none !important;
 }

--- a/src/theme/Admonition/Icon/Danger.js
+++ b/src/theme/Admonition/Icon/Danger.js
@@ -1,0 +1,8 @@
+import React from 'react';
+export default function AdmonitionIconDanger(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <path d="M5 3H3v18h18V3H5zm14 2v14H5V5h14zm-8 4H9V7H7v2h2v2h2v2H9v2H7v2h2v-2h2v-2h2v2h2v2h2v-2h-2v-2h-2v-2h2V9h2V7h-2v2h-2v2h-2V9z" />
+    </svg>
+  );
+}

--- a/src/theme/Admonition/Icon/Info.js
+++ b/src/theme/Admonition/Icon/Info.js
@@ -1,0 +1,8 @@
+import React from 'react';
+export default function AdmonitionIconInfo(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <path d="M3 3h2v18H3V3zm16 0H5v2h14v14H5v2h16V3h-2zm-8 6h2V7h-2v2zm2 8h-2v-6h2v6z" />
+    </svg>
+  );
+}

--- a/src/theme/Admonition/Icon/Note.js
+++ b/src/theme/Admonition/Icon/Note.js
@@ -1,0 +1,8 @@
+import React from 'react';
+export default function AdmonitionIconNote(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <path d="M5 2h16v20H3V2h2zm14 18V4H5v16h14zM7 6h10v2H7V6zm10 4H7v2h10v-2zM7 14h7v2H7v-2z" />
+    </svg>
+  );
+}

--- a/src/theme/Admonition/Icon/Tip.js
+++ b/src/theme/Admonition/Icon/Tip.js
@@ -1,0 +1,8 @@
+import React from 'react';
+export default function AdmonitionIconTip(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <path d="M8 2h8v2H8V2ZM6 6V4h2v2H6Zm0 6H4V6h2v6Zm2 2H6v-2h2v2Zm8 0v4H8v-4h2v2h4v-2h2Zm2-2v2h-2v-2h2Zm0-6h2v6h-2V6Zm0 0V4h-2v2h2Zm-2 14H8v2h8v-2Z" />
+    </svg>
+  );
+}

--- a/src/theme/Admonition/Icon/Warning.js
+++ b/src/theme/Admonition/Icon/Warning.js
@@ -1,0 +1,8 @@
+import React from 'react';
+export default function AdmonitionIconWarning(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <path d="M13 1h-2v2H9v2H7v2H5v2H3v2H1v2h2v2h2v2h2v2h2v2h2v2h2v-2h2v-2h2v-2h2v-2h2v-2h2v-2h-2V9h-2V7h-2V5h-2V3h-2V1zm0 2v2h2v2h2v2h2v2h2v2h-2v2h-2v2h-2v2h-2v2h-2v-2H9v-2H7v-2H5v-2H3v-2h2V9h2V7h2V5h2V3h2zm0 4h-2v6h2V7zm0 8h-2v2h2v-2z" />
+    </svg>
+  );
+}

--- a/src/theme/BackToTopButton/index.tsx
+++ b/src/theme/BackToTopButton/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {useBackToTopButton} from '@docusaurus/theme-common/internal';
+import styles from './styles.module.css';
+
+export default function BackToTopButton(): JSX.Element | null {
+  const {shown, scrollToTop} = useBackToTopButton({threshold: 300});
+
+  return (
+    <button
+      aria-label="Scroll back to top"
+      className={`${styles.backToTop} ${shown ? styles.shown : ''}`}
+      type="button"
+      onClick={scrollToTop}
+    >
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M18 15l-6-6-6 6" />
+      </svg>
+    </button>
+  );
+}

--- a/src/theme/BackToTopButton/styles.module.css
+++ b/src/theme/BackToTopButton/styles.module.css
@@ -1,0 +1,45 @@
+.backToTop {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  cursor: pointer;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(8px);
+  color: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  transform: translateY(8px);
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease, color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.backToTop:hover {
+  background: rgba(255, 255, 255, 0.95);
+  color: rgba(0, 0, 0, 0.8);
+  border-color: rgba(0, 0, 0, 0.3);
+}
+
+.shown {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+[data-theme='dark'] .backToTop {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(30, 30, 30, 0.8);
+  color: rgba(255, 255, 255, 0.5);
+}
+
+[data-theme='dark'] .backToTop:hover {
+  background: rgba(30, 30, 30, 0.95);
+  color: rgba(255, 255, 255, 0.8);
+  border-color: rgba(255, 255, 255, 0.4);
+}

--- a/src/theme/DocItem/Layout/EndBar.tsx
+++ b/src/theme/DocItem/Layout/EndBar.tsx
@@ -1,4 +1,5 @@
-import React, {type ReactNode} from 'react';
+import React, {type ReactNode, useState, useLayoutEffect} from 'react';
+import {createPortal} from 'react-dom';
 import {useDoc} from '@docusaurus/plugin-content-docs/client';
 
 function GitHubIcon(): ReactNode {
@@ -14,10 +15,7 @@ function GitHubIcon(): ReactNode {
   );
 }
 
-export default function EndBar(): ReactNode {
-  const {metadata} = useDoc();
-  const {editUrl} = metadata;
-
+function EndBarContent({editUrl}: {editUrl?: string}): ReactNode {
   return (
     <div className="doc-end-bar-wrapper">
       <div className="doc-end-bar">
@@ -47,4 +45,34 @@ export default function EndBar(): ReactNode {
       </div>
     </div>
   );
+}
+
+export default function EndBar(): ReactNode {
+  const {metadata} = useDoc();
+  const {editUrl} = metadata;
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+
+  useLayoutEffect(() => {
+    const paginationNav = document.querySelector('nav.pagination-nav');
+    if (!paginationNav?.parentElement) return;
+
+    let target = paginationNav.parentElement.querySelector(
+      '.end-bar-portal',
+    ) as HTMLElement | null;
+    if (!target) {
+      target = document.createElement('div');
+      target.className = 'end-bar-portal';
+      paginationNav.parentElement.appendChild(target);
+    }
+    setPortalTarget(target);
+
+    return () => {
+      target?.remove();
+      setPortalTarget(null);
+    };
+  }, []);
+
+  if (!portalTarget) return null;
+
+  return createPortal(<EndBarContent editUrl={editUrl} />, portalTarget);
 }

--- a/src/theme/DocItem/Layout/MarkdownToggle.module.css
+++ b/src/theme/DocItem/Layout/MarkdownToggle.module.css
@@ -81,6 +81,14 @@
   height: 12px;
 }
 
+:global([data-theme='dark']) .rawModeBg {
+  background-color: #1a2236;
+}
+
+.rawModeBg {
+  background-color: #CCCCCC;
+}
+
 .rawContent {
   font-family: 'Jetbrainsmono', monospace;
   font-size: 13px;
@@ -93,6 +101,10 @@
   border: 1px solid var(--docs-border);
   color: var(--docs-text);
   overflow-x: auto;
+}
+
+:global([data-theme='dark']) .rawContent {
+  background: var(--docs-bg-subtle);
 }
 
 .loading {

--- a/src/theme/DocItem/Layout/MarkdownToggle.tsx
+++ b/src/theme/DocItem/Layout/MarkdownToggle.tsx
@@ -146,18 +146,18 @@ export default function MarkdownToggle({children}: Props): ReactNode {
     };
   }, [viewState, editUrl]);
 
-  // Apply/remove grey background on the doc main container
+  // Apply/remove background class on the doc main container
   useEffect(() => {
     const el = document.querySelector<HTMLElement>('[class*="docMainContainer"]');
     if (!el) return;
-    const showGrey = viewState !== 'rendered';
-    if (showGrey) {
-      el.style.backgroundColor = '#CCCCCC';
+    const showBg = viewState !== 'rendered';
+    if (showBg) {
+      el.classList.add(styles.rawModeBg);
     } else {
-      el.style.backgroundColor = '';
+      el.classList.remove(styles.rawModeBg);
     }
     return () => {
-      el.style.backgroundColor = '';
+      el.classList.remove(styles.rawModeBg);
     };
   }, [viewState]);
 

--- a/src/theme/Footer/Footer.module.css
+++ b/src/theme/Footer/Footer.module.css
@@ -1,8 +1,22 @@
 .footer {
   background: #fafafa;
   border-top: 1px solid #e5e7eb;
-  padding: 3rem 0 1.5rem;
+  padding: 3.5rem 0 1.5rem;
   margin-top: auto;
+  position: relative;
+}
+
+.footer::before {
+  content: '';
+  position: absolute;
+  top: 4px;
+  left: 0;
+  right: 0;
+  height: 8px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='8' viewBox='0 0 6 8' shape-rendering='crispEdges'%3E%3Crect x='4' y='0' width='2' height='2' fill='rgba(156,163,175,0.35)'/%3E%3Crect x='3' y='2' width='2' height='2' fill='rgba(156,163,175,0.35)'/%3E%3Crect x='2' y='4' width='2' height='2' fill='rgba(156,163,175,0.35)'/%3E%3Crect x='1' y='6' width='2' height='2' fill='rgba(156,163,175,0.35)'/%3E%3C/svg%3E");
+  background-repeat: repeat-x;
+  background-size: 6px 8px;
+  image-rendering: pixelated;
 }
 
 .footerInner {
@@ -192,6 +206,7 @@
 
 .legalLinks {
   display: flex;
+  align-items: center;
   gap: 1.5rem;
 }
 
@@ -235,6 +250,106 @@
   }
 }
 
+/* Footer Theme Toggle */
+.footerThemeToggle {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.themeButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid #d1d5db;
+  background: transparent;
+  color: #9ca3af;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.themeButton:hover {
+  color: #4b5563;
+  border-color: #9ca3af;
+}
+
+.themeIconWrapper {
+  position: relative;
+  display: block;
+  width: 14px;
+  height: 14px;
+  overflow: hidden;
+}
+
+.themeIcon {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.sunIcon {
+  transform: rotate(-90deg) scale(0);
+  opacity: 0;
+}
+
+.moonIcon {
+  transform: rotate(0deg) scale(1);
+  opacity: 1;
+}
+
+:global([data-theme='dark']) .sunIcon {
+  transform: rotate(0deg) scale(1);
+  opacity: 1;
+}
+
+:global([data-theme='dark']) .moonIcon {
+  transform: rotate(90deg) scale(0);
+  opacity: 0;
+}
+
+.themeTooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  padding: 4px 8px;
+  background: #1a1f2e;
+  color: #f3f4f6;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.footerThemeToggle:hover .themeTooltip {
+  opacity: 1;
+}
+
+:global([data-theme='dark']) .themeButton {
+  color: rgba(255, 255, 255, 0.5);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+:global([data-theme='dark']) .themeButton:hover {
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+:global([data-theme='dark']) .themeTooltip {
+  background: #374151;
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
 /* ==========================================================================
    DARK MODE
    ========================================================================== */
@@ -242,6 +357,10 @@
 :global([data-theme='dark']) .footer {
   background: #0943bf;
   border-top: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+:global([data-theme='dark']) .footer::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='8' viewBox='0 0 6 8' shape-rendering='crispEdges'%3E%3Crect x='4' y='0' width='2' height='2' fill='rgba(255,255,255,0.3)'/%3E%3Crect x='3' y='2' width='2' height='2' fill='rgba(255,255,255,0.3)'/%3E%3Crect x='2' y='4' width='2' height='2' fill='rgba(255,255,255,0.3)'/%3E%3Crect x='1' y='6' width='2' height='2' fill='rgba(255,255,255,0.3)'/%3E%3C/svg%3E");
 }
 
 :global([data-theme='dark']) .logo {

--- a/src/theme/Footer/Footer.module.css
+++ b/src/theme/Footer/Footer.module.css
@@ -234,3 +234,89 @@
     justify-content: center;
   }
 }
+
+/* ==========================================================================
+   DARK MODE
+   ========================================================================== */
+
+:global([data-theme='dark']) .footer {
+  background: #0943bf;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+:global([data-theme='dark']) .logo {
+  color: #ffffff;
+}
+
+:global([data-theme='dark']) .logo:hover {
+  color: #ffffff;
+}
+
+:global([data-theme='dark']) .tagline {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+:global([data-theme='dark']) .newsletterLabel {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+:global([data-theme='dark']) .newsletterInput {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.25);
+  color: #ffffff;
+}
+
+:global([data-theme='dark']) .newsletterInput::placeholder {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+:global([data-theme='dark']) .newsletterInput:focus {
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+:global([data-theme='dark']) .newsletterButton {
+  background: #ffffff;
+  color: #0943bf;
+  border-color: #ffffff;
+}
+
+:global([data-theme='dark']) .newsletterButton:hover {
+  background: rgba(255, 255, 255, 0.9);
+  border-color: rgba(255, 255, 255, 0.9);
+}
+
+:global([data-theme='dark']) .columnTitle {
+  color: #ffffff !important;
+}
+
+:global([data-theme='dark']) .linkList a {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+:global([data-theme='dark']) .linkList a:hover {
+  color: #ffffff;
+}
+
+:global([data-theme='dark']) .socialLink {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+:global([data-theme='dark']) .socialLink:hover {
+  color: #ffffff;
+}
+
+:global([data-theme='dark']) .divider {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+:global([data-theme='dark']) .copyright {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+:global([data-theme='dark']) .legalLinks a {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+:global([data-theme='dark']) .legalLinks a:hover {
+  color: rgba(255, 255, 255, 0.75);
+}

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
+import {useColorMode} from '@docusaurus/theme-common';
 import styles from './Footer.module.css';
 
 function ArrowLogo() {
@@ -52,6 +53,49 @@ function DiscordIcon() {
     <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
       <path d="M19.27 5.33C17.94 4.71 16.5 4.26 15 4a.1.1 0 0 0-.07.03c-.18.33-.39.76-.53 1.09a16.1 16.1 0 0 0-4.8 0c-.14-.34-.35-.76-.54-1.09c-.01-.02-.04-.03-.07-.03c-1.5.26-2.93.71-4.27 1.33c-.01 0-.02.01-.03.02c-2.72 4.07-3.47 8.03-3.1 11.95c0 .02.01.04.03.05c1.8 1.32 3.53 2.12 5.24 2.65c.03.01.06 0 .07-.02c.4-.55.76-1.13 1.07-1.74c.02-.04 0-.08-.04-.09c-.57-.22-1.11-.48-1.64-.78c-.04-.02-.04-.08-.01-.11c.11-.08.22-.17.33-.25c.02-.02.05-.02.07-.01c3.44 1.57 7.15 1.57 10.55 0c.02-.01.05-.01.07.01c.11.09.22.17.33.26c.04.03.04.09-.01.11c-.52.31-1.07.56-1.64.78c-.04.01-.05.06-.04.09c.32.61.68 1.19 1.07 1.74c.03.01.06.02.09.01c1.72-.53 3.45-1.33 5.25-2.65c.02-.01.03-.03.03-.05c.44-4.53-.73-8.46-3.1-11.95c-.01-.01-.02-.02-.04-.02M8.52 14.91c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.84 2.12-1.89 2.12m6.97 0c-1.03 0-1.89-.95-1.89-2.12s.84-2.12 1.89-2.12c1.06 0 1.9.96 1.89 2.12c0 1.17-.83 2.12-1.89 2.12"></path>
     </svg>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function FooterThemeToggle() {
+  const {colorMode, setColorMode} = useColorMode();
+  const isDark = colorMode === 'dark';
+
+  return (
+    <div className={styles.footerThemeToggle}>
+      <button
+        className={styles.themeButton}
+        type="button"
+        onClick={() => setColorMode(isDark ? 'light' : 'dark')}
+        aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
+      >
+        <span className={styles.themeIconWrapper}>
+          <span className={`${styles.themeIcon} ${styles.sunIcon}`}>
+            <SunIcon />
+          </span>
+          <span className={`${styles.themeIcon} ${styles.moonIcon}`}>
+            <MoonIcon />
+          </span>
+        </span>
+      </button>
+      <span className={styles.themeTooltip}>Toggle theme</span>
+    </div>
   );
 }
 
@@ -109,12 +153,7 @@ export default function Footer(): JSX.Element {
                 <a href="https://discord.com/invite/arrow" target="_blank" rel="noopener noreferrer" className={styles.socialLink}>
                   <DiscordIcon /> Discord
                 </a>
-                <a href="#" className={styles.socialLink}>
-                  <XIcon /> X
-                </a>
-                <a href="#" className={styles.socialLink}>
-                  <LinkedInIcon /> LinkedIn
-                </a>
+                {/* TODO: Add real X/Twitter and LinkedIn URLs when available */}
               </div>
             </div>
           </div>
@@ -127,6 +166,7 @@ export default function Footer(): JSX.Element {
         <div className={styles.bottomSection}>
           <p className={styles.copyright}>© 2026 Arrow. All rights reserved.</p>
           <div className={styles.legalLinks}>
+            <FooterThemeToggle />
             <a href="#">Privacy Policy</a>
             <a href="#">Terms of Service</a>
           </div>

--- a/src/theme/Navbar/DocsNavbar.module.css
+++ b/src/theme/Navbar/DocsNavbar.module.css
@@ -49,6 +49,27 @@
   gap: 0.75rem;
 }
 
+.mainSiteLink {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.7);
+  text-decoration: none;
+  padding: 6px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.mainSiteLink:hover {
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.5);
+  text-decoration: none;
+}
+
 .searchWrapper {
   margin-right: 0.25rem;
 }
@@ -72,10 +93,85 @@
   text-decoration: none;
 }
 
-.colorModeToggle {
+/* Theme toggle (shadcn-style) */
+.themeToggle {
+  position: relative;
   display: flex;
   align-items: center;
-  color: rgba(255, 255, 255, 0.7);
+}
+
+.themeIconWrapper {
+  position: relative;
+  display: block;
+  width: 20px;
+  height: 20px;
+  overflow: hidden;
+}
+
+.themeIcon {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+/* Light mode: show moon (switch to dark) */
+.sunIcon {
+  transform: rotate(-90deg) scale(0);
+  opacity: 0;
+}
+
+.moonIcon {
+  transform: rotate(0deg) scale(1);
+  opacity: 1;
+}
+
+/* Dark mode: show sun (switch to light) */
+:global([data-theme='dark']) .sunIcon {
+  transform: rotate(0deg) scale(1);
+  opacity: 1;
+}
+
+:global([data-theme='dark']) .moonIcon {
+  transform: rotate(90deg) scale(0);
+  opacity: 0;
+}
+
+/* Tooltip */
+.tooltip {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 101;
+  padding: 4px 8px;
+  background: #1a1f2e;
+  color: #f3f4f6;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+:global([data-theme='dark']) .tooltip {
+  background: #374151;
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.themeToggle:hover .tooltip,
+.tooltipWrapper:hover .tooltip {
+  opacity: 1;
+}
+
+.tooltipWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
 }
 
 /* Mobile responsive */

--- a/src/theme/Navbar/index.tsx
+++ b/src/theme/Navbar/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import NavbarOriginal from '@theme-original/Navbar';
 import Link from '@docusaurus/Link';
-import ColorModeToggle from '@theme/ColorModeToggle';
 import {useColorMode} from '@docusaurus/theme-common';
 import SearchBar from '@theme/SearchBar';
 import styles from './DocsNavbar.module.css';
@@ -35,9 +34,50 @@ function DiscordIcon() {
   );
 }
 
-function DocsNavbar() {
-  const {colorMode, setColorMode} = useColorMode();
+function SunIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+    </svg>
+  );
+}
 
+function MoonIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function ThemeToggle() {
+  const {colorMode, setColorMode} = useColorMode();
+  const isDark = colorMode === 'dark';
+
+  return (
+    <div className={styles.themeToggle}>
+      <button
+        className={styles.iconButton}
+        type="button"
+        onClick={() => setColorMode(isDark ? 'light' : 'dark')}
+        aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
+      >
+        <span className={styles.themeIconWrapper}>
+          <span className={`${styles.themeIcon} ${styles.sunIcon}`}>
+            <SunIcon />
+          </span>
+          <span className={`${styles.themeIcon} ${styles.moonIcon}`}>
+            <MoonIcon />
+          </span>
+        </span>
+      </button>
+      <span className={styles.tooltip}>Toggle theme</span>
+    </div>
+  );
+}
+
+function DocsNavbar() {
   return (
     <nav className={styles.navbar}>
       <div className={styles.navbarInner}>
@@ -48,32 +88,43 @@ function DocsNavbar() {
 
         {/* Right Actions */}
         <div className={styles.navActions}>
+          <a
+            href="https://www.arrowair.com"
+            className={styles.mainSiteLink}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 244.04 271.73" fill="currentColor" aria-hidden>
+              <polygon points="203.47 159.39 153.11 148.22 122.02 232.71 90.93 148.22 40.57 159.39 122.02 39.29 203.47 159.39"/>
+            </svg>
+            MAIN SITE
+          </a>
           <div className={styles.searchWrapper}>
             <SearchBar />
           </div>
-          <a
-            href="https://github.com/Arrow-air"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.iconButton}
-            aria-label="GitHub"
-          >
-            <GitHubIcon />
-          </a>
-          <a
-            href="https://discord.com/invite/arrow"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.iconButton}
-            aria-label="Discord"
-          >
-            <DiscordIcon />
-          </a>
-          <ColorModeToggle
-            className={styles.colorModeToggle}
-            value={colorMode}
-            onChange={setColorMode}
-          />
+          <div className={styles.tooltipWrapper}>
+            <a
+              href="https://github.com/Arrow-air"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.iconButton}
+              aria-label="GitHub"
+            >
+              <GitHubIcon />
+            </a>
+            <span className={styles.tooltip}>GitHub</span>
+          </div>
+          <div className={styles.tooltipWrapper}>
+            <a
+              href="https://discord.com/invite/arrow"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.iconButton}
+              aria-label="Discord"
+            >
+              <DiscordIcon />
+            </a>
+            <span className={styles.tooltip}>Discord</span>
+          </div>
+          <ThemeToggle />
         </div>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- Full dark mode support across docs theme (navbar, footer, sidebar, content, admonitions, pagination, breadcrumbs, code blocks)
- Custom animated sun/moon theme toggle in navbar and footer
- Custom pixel-art admonition icons (note, tip, info, warning, danger)
- Custom back-to-top button component
- Portal EndBar into content column for consistent width alignment with pagination-nav
- CLA page dark mode styles
- Add MAIN SITE link and icon tooltips to docs navbar
- Move playwright to devDependencies

## Test plan
- [ ] Toggle dark/light mode via navbar and footer buttons — all elements should theme correctly
- [ ] Check admonition types (note, tip, info, warning, danger) in both modes
- [ ] Verify end bar and pagination nav are same width on pages with and without TOC
- [ ] Check narrow viewports for no overflow
- [ ] Verify CLA page renders correctly in dark mode