### PR TITLE
fix: repair docs footer routes and quiver import link

### DIFF
--- a/scripts/import-external-docs.sh
+++ b/scripts/import-external-docs.sh
@@ -95,6 +95,14 @@ for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
 			"$mdfile" 2>/dev/null || true
 	done
 
+	# Patch known upstream links that do not resolve cleanly in the website's
+	# Docusaurus route structure after import.
+	if [ "$key" = "project-quiver" ] && [ -f "$target_path/index.md" ]; then
+		$SED_INPLACE \
+			-e 's|\[Engineering Reports\](\./Engineering-Reports/)|[Engineering Reports](/quiver/category/engineering-reports/)|g' \
+			"$target_path/index.md" 2>/dev/null || true
+	fi
+
 	# Create _category_.json for sidebar only when importing into the default docs/ subfolder
 	# (not needed for top-level plugin roots specified via targetPath)
 	custom_target=$(jq -r ".\"$key\".targetPath // \"\"" "$CONFIG_FILE")

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -107,9 +107,9 @@ export default function Footer(): JSX.Element {
         <div className={styles.topSection}>
           {/* Left - Logo & Newsletter */}
           <div className={styles.leftColumn}>
-            <Link to="/" className={styles.logo}>
+            <a href="/index.html" className={styles.logo}>
               <ArrowLogo />
-            </Link>
+            </a>
             <p className={styles.tagline}>
               Building open source aircraft for humanity.
             </p>
@@ -120,9 +120,9 @@ export default function Footer(): JSX.Element {
             <div className={styles.linkColumn}>
               <h4 className={styles.columnTitle}>Engineering</h4>
               <ul className={styles.linkList}>
-                <li><Link to="/docs/project-quiver">Project Quiver</Link></li>
+                <li><Link to="/quiver">Project Quiver</Link></li>
                 <li><a href="https://github.com/Arrow-air" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-                <li><Link to="/docs">Documentation</Link></li>
+                <li><Link to="/docs/intro">Documentation</Link></li>
               </ul>
             </div>
 
@@ -140,7 +140,7 @@ export default function Footer(): JSX.Element {
               <ul className={styles.linkList}>
                 <li><a href="https://snapshot.org/#/s:arrowair.eth" target="_blank" rel="noopener noreferrer">Snapshot</a></li>
                 <li><a href="https://github.com/Arrow-air/dao-aips" target="_blank" rel="noopener noreferrer">AIPs</a></li>
-                <li><Link to="/dao">Overview</Link></li>
+                <li><a href="/dao.html">Overview</a></li>
               </ul>
             </div>
 
@@ -167,8 +167,8 @@ export default function Footer(): JSX.Element {
           <p className={styles.copyright}>© 2026 Arrow. All rights reserved.</p>
           <div className={styles.legalLinks}>
             <FooterThemeToggle />
-            <a href="#">Privacy Policy</a>
-            <a href="#">Terms of Service</a>
+            <Link to="/privacy-policy">Privacy Policy</Link>
+            <Link to="/terms-of-service">Terms of Service</Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix broken footer routes for homepage, Quiver, docs home, DAO overview, and legal pages
- rewrite the imported Project Quiver Engineering Reports link so it matches the website route structure

## Verification
- npm run build
- confirmed the repeated footer/Quiver broken-link warnings are gone

## Notes
- remaining broken-link warnings are unrelated content issues already present elsewhere in the branch