### PR TITLE
fix: improve animation easings and add mega menu stagger

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -632,8 +632,9 @@ h1, .h1 {
   content: "";
   width: 0.65em;
   height: 0.65em;
-  transform: scale(0);
-  transition: 120ms transform ease-in-out;
+  transform: scale(0.7);
+  opacity: 0;
+  transition: transform 120ms ease-out, opacity 100ms ease-out;
   box-shadow: inset 1em 1em #663399;
   transform-origin: bottom left;
   clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
@@ -641,6 +642,7 @@ h1, .h1 {
 
 .sign-cla input[type="checkbox"]:checked::before {
   transform: scale(1);
+  opacity: 1;
 }
 
 .sign-cla .cla-scroll-box {
@@ -3963,9 +3965,7 @@ kbd[class*="searchHint"] {
   transition: filter 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-a.card--link:hover::before {
-  filter: saturate(1) opacity(1);
-}
+/* card hover rules consolidated below in @media (hover: hover) */
 
 .cards--cols-3 .card::before {
   background-image: url('/img/card-bayer-90.svg');
@@ -4037,9 +4037,7 @@ a.card--link:hover::before {
   transition: filter 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-a.card--link:hover .card__image {
-  filter: saturate(1) opacity(1);
-}
+/* card__image hover → consolidated below */
 
 /* Themed card images — 4 states: dark/light × unhover/hover */
 .card__image--dark-unhover,
@@ -4050,26 +4048,16 @@ a.card--link:hover .card__image {
   transition: opacity 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-a.card--link:hover .card__image--dark-unhover,
-a.card--link:hover .card__image--light-unhover,
-a.card--link:hover .card__image--hover {
-  filter: none;
-}
-
 /* Dark mode */
 [data-theme='dark'] .card__image--dark-unhover { opacity: 1; }
-[data-theme='dark'] a.card--link:hover .card__image--dark-unhover { opacity: 0; }
 
 /* Light mode */
 [data-theme='light'] .card__image--light-unhover { opacity: 1; }
-[data-theme='light'] a.card--link:hover .card__image--light-unhover { opacity: 0; }
 
 /* Fallback: if no light image provided, show dark in light mode too */
 :not([data-theme='light']) .card__image--dark-unhover { opacity: 1; }
-:not([data-theme='light']) a.card--link:hover .card__image--dark-unhover { opacity: 0; }
 
-/* Single hover image — both modes */
-a.card--link:hover .card__image--hover { opacity: 1; }
+/* themed image hover states → consolidated below */
 
 
 .card__media-icon {
@@ -4081,9 +4069,7 @@ a.card--link:hover .card__image--hover { opacity: 1; }
   transition: opacity 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-a.card--link:hover .card__media-icon {
-  opacity: 1;
-}
+/* card__media-icon hover → consolidated below */
 
 .card__media-icon svg {
   width: 40px;
@@ -4102,30 +4088,7 @@ a.card--link:hover .card__media-icon {
   transition: background 0.15s ease;
 }
 
-a.card--link:hover {
-  background: var(--card-hover-color);
-  border-color: #6D8ED9;
-  transform: translateY(-4px);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
-}
-
-a.card--link:hover .card__media,
-a.card--link:hover .card__media-wrapper::before,
-a.card--link:hover .card__media-wrapper::after {
-  background-color: var(--docs-bg);
-}
-
-
-
-a.card--link:hover .card__media-wrapper::before,
-a.card--link:hover .card__media-wrapper::after,
-a.card--link:hover .card__media {
-  border-color: #A8BCE8;
-}
-
-a.card--link:hover .card__content {
-  background: transparent;
-}
+/* card main hover → consolidated below */
 
 @keyframes card-arrow-pulse {
   0%   { transform: translateX(0); }
@@ -4169,10 +4132,7 @@ a.card--link:hover .card__content {
   transition: opacity 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-a.card--link:hover .card__title-arrow {
-  opacity: 0.9;
-  animation: card-arrow-pulse 0.4s ease-out forwards;
-}
+/* card__title-arrow hover → consolidated below */
 
 .card__body,
 .card__body p {
@@ -4184,19 +4144,75 @@ a.card--link:hover .card__title-arrow {
   transition: color 0.15s ease;
 }
 
-a.card--link:hover .card__body,
-a.card--link:hover .card__body p {
-  color: #3d5270;
-}
-
 [data-theme='dark'] .card__body,
 [data-theme='dark'] .card__body p {
   color: var(--docs-text-muted);
 }
 
-[data-theme='dark'] a.card--link:hover .card__body,
-[data-theme='dark'] a.card--link:hover .card__body p {
-  color: var(--docs-text-secondary);
+/* card__body hover + dark card__body hover → consolidated below */
+
+/* ── Card hover effects (pointer devices only) ───────────────────────────── */
+@media (hover: hover) and (pointer: fine) {
+  a.card--link:hover::before {
+    filter: saturate(1) opacity(1);
+  }
+
+  a.card--link:hover .card__image {
+    filter: saturate(1) opacity(1);
+  }
+
+  a.card--link:hover .card__image--dark-unhover,
+  a.card--link:hover .card__image--light-unhover,
+  a.card--link:hover .card__image--hover {
+    filter: none;
+  }
+
+  [data-theme='dark'] a.card--link:hover .card__image--dark-unhover { opacity: 0; }
+  [data-theme='light'] a.card--link:hover .card__image--light-unhover { opacity: 0; }
+  :not([data-theme='light']) a.card--link:hover .card__image--dark-unhover { opacity: 0; }
+  a.card--link:hover .card__image--hover { opacity: 1; }
+
+  a.card--link:hover .card__media-icon {
+    opacity: 1;
+  }
+
+  a.card--link:hover {
+    background: var(--card-hover-color);
+    border-color: #6D8ED9;
+    transform: translateY(-4px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+  }
+
+  a.card--link:hover .card__media,
+  a.card--link:hover .card__media-wrapper::before,
+  a.card--link:hover .card__media-wrapper::after {
+    background-color: var(--docs-bg);
+  }
+
+  a.card--link:hover .card__media-wrapper::before,
+  a.card--link:hover .card__media-wrapper::after,
+  a.card--link:hover .card__media {
+    border-color: #A8BCE8;
+  }
+
+  a.card--link:hover .card__content {
+    background: transparent;
+  }
+
+  a.card--link:hover .card__title-arrow {
+    opacity: 0.9;
+    animation: card-arrow-pulse 0.4s ease-out forwards;
+  }
+
+  a.card--link:hover .card__body,
+  a.card--link:hover .card__body p {
+    color: #3d5270;
+  }
+
+  [data-theme='dark'] a.card--link:hover .card__body,
+  [data-theme='dark'] a.card--link:hover .card__body p {
+    color: var(--docs-text-secondary);
+  }
 }
 
 /* ==========================================================================
@@ -4248,4 +4264,29 @@ a.card--link:hover .card__body p {
 /* Constitution page — extra heading spacing */
 .theme-doc-markdown:has(h2[id^="article-1"]) h3 {
   margin-top: 2.5rem;
+}
+
+/* ── Reduced motion ─────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  a.card--link,
+  .card__image,
+  .card__image--dark-unhover,
+  .card__image--light-unhover,
+  .card__image--hover,
+  .card__media-icon,
+  .card__title-arrow,
+  .card__body,
+  .card__body p,
+  .card__media,
+  .card__media-wrapper::before,
+  .card__media-wrapper::after,
+  .card__content {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+
+  .sign-cla input[type="checkbox"]::before {
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1058,7 +1058,7 @@ figcaption {
   margin-top: 0;
   margin-left: -1.25rem;
   margin-right: .5rem;
-  transition: all .2s;
+  transition: border-color 0.2s ease-out, background-color 0.2s ease-out;
 }
 
 .form_checkbox-icon:hover {
@@ -1413,7 +1413,7 @@ figcaption {
   padding: .5rem .75rem;
   font-size: 1rem;
   line-height: 1.6;
-  transition: all .2s;
+  transition: border-color 0.2s ease-out, background-color 0.2s ease-out;
 }
 
 .form_input:hover {
@@ -1630,7 +1630,7 @@ figcaption {
   margin-top: 0;
   margin-left: -1.125rem;
   margin-right: .5rem;
-  transition: all .2s;
+  transition: border-color 0.2s ease-out, background-color 0.2s ease-out;
 }
 
 .form_radio-icon:hover {
@@ -2451,6 +2451,65 @@ figcaption {
   padding: 0;
 }
 
+/* ── Mega menu stagger animations ─────────────────────────────────────────
+   Columns are the primary stagger element — 70ms between each so the
+   left-to-right cascade is clearly perceptible. Links don't stagger
+   independently; they appear with their column so the menu stays readable.
+   ── */
+@keyframes megaMenuPanelIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes megaMenuItemIn {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.arrow-navbar_dropdown-list.w--open {
+  animation: megaMenuPanelIn 200ms cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+
+/* Columns stagger — 70ms spacing so each arrival is distinct */
+.arrow-navbar_dropdown-list.w--open .arrow-navbar_dropdown-column:nth-child(1) {
+  animation: megaMenuItemIn 320ms cubic-bezier(0.23, 1, 0.32, 1) 30ms both;
+}
+.arrow-navbar_dropdown-list.w--open .arrow-navbar_dropdown-column:nth-child(2) {
+  animation: megaMenuItemIn 320ms cubic-bezier(0.23, 1, 0.32, 1) 100ms both;
+}
+.arrow-navbar_dropdown-list.w--open .arrow-navbar_dropdown-column:nth-child(3) {
+  animation: megaMenuItemIn 320ms cubic-bezier(0.23, 1, 0.32, 1) 170ms both;
+}
+
+/* Right-panel small links stagger — subtler, coordinated with column rhythm */
+.arrow-navbar_dropdown-list.w--open .arrow-navbar_dropdown-link-small.is-mega-menu:nth-child(1) {
+  animation: megaMenuItemIn 280ms cubic-bezier(0.23, 1, 0.32, 1) 80ms both;
+}
+.arrow-navbar_dropdown-list.w--open .arrow-navbar_dropdown-link-small.is-mega-menu:nth-child(2) {
+  animation: megaMenuItemIn 280ms cubic-bezier(0.23, 1, 0.32, 1) 120ms both;
+}
+.arrow-navbar_dropdown-list.w--open .arrow-navbar_dropdown-link-small.is-mega-menu:nth-child(3) {
+  animation: megaMenuItemIn 280ms cubic-bezier(0.23, 1, 0.32, 1) 160ms both;
+}
+.arrow-navbar_dropdown-list.w--open .arrow-navbar_dropdown-link-small.is-mega-menu:nth-child(4) {
+  animation: megaMenuItemIn 280ms cubic-bezier(0.23, 1, 0.32, 1) 200ms both;
+}
+.arrow-navbar_dropdown-list.w--open .arrow-navbar_dropdown-link-small.is-mega-menu:nth-child(5) {
+  animation: megaMenuItemIn 280ms cubic-bezier(0.23, 1, 0.32, 1) 240ms both;
+}
+.arrow-navbar_dropdown-list.w--open .arrow-navbar_dropdown-link-small.is-mega-menu:nth-child(6) {
+  animation: megaMenuItemIn 280ms cubic-bezier(0.23, 1, 0.32, 1) 280ms both;
+}
+
+/* Suppress motion for users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .arrow-navbar_dropdown-list.w--open,
+  .arrow-navbar_dropdown-list.w--open .arrow-navbar_dropdown-column,
+  .arrow-navbar_dropdown-list.w--open .arrow-navbar_dropdown-link-small.is-mega-menu {
+    animation: none;
+  }
+}
+
 .arrow-navbar_dropdown-list.w--open {
   border-top: 1px solid var(--_primitives---opacity--white-10);
   border-bottom: var(--_ui-styles---stroke--divider-width) solid var(--color-scheme-1--border);
@@ -2678,7 +2737,7 @@ figcaption {
   border-radius: var(--_ui-styles---radius--large);
   position: relative;
   overflow: visible;
-  animation: heroFadeUp 1s cubic-bezier(0.4, 0, 0.2, 1) 0.2s both;
+  animation: heroFadeUp 0.7s cubic-bezier(0.23, 1, 0.32, 1) 0.2s both;
 }
 
 .arrow-hero_image {
@@ -2962,7 +3021,7 @@ figcaption {
 .arrow-timeline_image {
   opacity: 0;
   transform: translateY(20px);
-  transition: transform 0.5s ease, opacity 0.6s ease;
+  transition: transform 0.4s ease-out, opacity 0.4s ease-out;
 }
 
 .arrow-timeline_image.in-view {
@@ -4468,7 +4527,7 @@ figcaption {
   backdrop-filter: blur(5px);
   -webkit-backdrop-filter: blur(5px);
   opacity: 0;
-  transition: opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: opacity 0.45s cubic-bezier(0.16, 1, 0.3, 1);
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 12px;
   box-shadow:
@@ -7910,7 +7969,7 @@ figcaption {
   display: grid;
   grid-template-rows: repeat(5, 36px);
   grid-auto-flow: column;
-  animation: graphReveal 1.4s cubic-bezier(0.4, 0, 0.2, 1) 0.3s both;
+  animation: graphReveal 1s cubic-bezier(0.23, 1, 0.32, 1) 0.3s both;
   grid-auto-columns: 36px;
   gap: 3.6px;
   padding: 90px 8px 24px;
@@ -7921,11 +7980,13 @@ figcaption {
   height: 36px;
   border-radius: 5px;
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), inset 0 -1px 0 rgba(0,0,0,0.2);
-  transition: transform 0.1s ease, filter 0.1s ease;
+  transition: transform 0.1s ease-out, filter 0.1s ease-out;
 }
-.ag-cell:hover {
-  transform: scale(1.15);
-  filter: brightness(1.5);
+@media (hover: hover) and (pointer: fine) {
+  .ag-cell:hover {
+    transform: scale(1.15);
+    filter: brightness(1.5);
+  }
 }
 .ag-level-0 { background: #171b22; }
 .ag-level-1 { background: #262A30; }
@@ -7991,18 +8052,32 @@ figcaption {
   transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
 }
 
-.button:hover,
-.button.is-icon:hover,
-.button.is-secondary:hover,
-.button.is-secondary.is-icon:hover,
-.button.is-secondary.is-alternate:hover,
-.button.is-alternate:hover,
-.button.w-button:hover,
-.button.is-secondary.w-button:hover {
-  color: #ffffff !important;
-  border-color: rgba(255, 255, 255, 0.5) !important;
-  background: rgba(0, 0, 0, 0.14) !important;
-  transform: none !important;
+@media (hover: hover) and (pointer: fine) {
+  .button:hover,
+  .button.is-icon:hover,
+  .button.is-secondary:hover,
+  .button.is-secondary.is-icon:hover,
+  .button.is-secondary.is-alternate:hover,
+  .button.is-alternate:hover,
+  .button.w-button:hover,
+  .button.is-secondary.w-button:hover {
+    color: #ffffff !important;
+    border-color: rgba(255, 255, 255, 0.5) !important;
+    background: rgba(0, 0, 0, 0.14) !important;
+    transform: none !important;
+  }
+}
+
+.button:active,
+.button.is-icon:active,
+.button.is-secondary:active,
+.button.is-secondary.is-icon:active,
+.button.is-secondary.is-alternate:active,
+.button.is-alternate:active,
+.button.w-button:active,
+.button.is-secondary.w-button:active {
+  transform: scale(0.97) !important;
+  transition-duration: 100ms !important;
 }
 
 .button.is-blue {
@@ -8042,7 +8117,7 @@ figcaption {
 [data-reveal] {
   opacity: 0;
   transform: translateY(24px);
-  transition: opacity 0.6s ease, transform 0.6s ease;
+  transition: opacity 0.4s ease-out, transform 0.4s ease-out;
 }
 
 [data-reveal].is-revealed {
@@ -8053,7 +8128,7 @@ figcaption {
 [data-reveal="fade"] {
   opacity: 0;
   transform: none;
-  transition: opacity 0.6s ease;
+  transition: opacity 0.4s ease-out;
 }
 
 [data-reveal="fade"].is-revealed {
@@ -8168,3 +8243,38 @@ a[target="_blank"]:hover::after {
   }
 }
 
+
+/* ── Reduced motion ─────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal] {
+    transition: opacity 0.2s ease;
+    transform: none !important;
+  }
+
+  .arrow-timeline_image {
+    transition: opacity 0.2s ease;
+    transform: none !important;
+  }
+
+  .arrow-timeline_image.in-view:hover {
+    transform: none;
+  }
+
+  .solution-card-glass {
+    transition: opacity 0.2s ease;
+  }
+
+  .arrow-hero_image-wrapper {
+    animation: none;
+    opacity: 1;
+  }
+
+  .activity-graph {
+    animation: none;
+    clip-path: none;
+  }
+
+  .ag-cell {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary

- Replace `transition: all` with specific properties on form elements (checkbox, input, radio)
- Fix CLA checkbox entry: `scale(0)` → `scale(0.7) + opacity`, `ease-in-out` → `ease-out`
- Tighten scroll reveal timings from 0.5–0.8s down to 0.4s with `ease-out`
- Wrap all button and card hover effects in `@media (hover: hover) and (pointer: fine)` so touch devices don't get stuck hover states
- Add button `:active { transform: scale(0.97) }` press feedback across all button variants
- Swap hero and activity graph entry animation curves to strong ease-out `cubic-bezier(0.23, 1, 0.32, 1)`
- Add mega menu column stagger on open: 70ms spacing, 320ms duration, 12px rise — columns cascade left to right, no exit animation (intentional)
- Add `@media (prefers-reduced-motion: reduce)` coverage in both `main.css` and `custom.css`

## Test plan

- [ ] Hover Quicklinks mega menu — columns should stagger in left to right
- [ ] Hover away from mega menu — closes instantly, no lingering animation
- [ ] Click any `.button` — should feel a subtle scale-down press response
- [ ] Test on a touch device / mobile — card hover lift should not trigger on tap
- [ ] Check scroll reveal sections (homepage timeline, How We Win cards) feel snappier
- [ ] Enable "Reduce Motion" in OS accessibility settings — all movement animations should be suppressed