### PR TITLE
Serve imported doc assets at route paths

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -86,6 +86,7 @@ const config = {
       path: 'docs/project-quiver',
       routeBasePath: 'quiver',
       sidebarPath: require.resolve('./sidebars-quiver.js'),
+      exclude: ['**/Archive/**'],
       editUrl: 'https://github.com/Arrow-air/project-quiver/edit/main/docs/',
       showLastUpdateTime: true,
     }],

--- a/scripts/import-external-docs.sh
+++ b/scripts/import-external-docs.sh
@@ -95,6 +95,30 @@ for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
 			"$mdfile" 2>/dev/null || true
 	done
 
+	# Docusaurus processes Markdown image syntax into hashed build assets, but
+	# raw HTML <img src="..."> tags and links to binary assets keep their
+	# relative URLs. Mirror imported non-doc assets under the public route so
+	# those relative URLs resolve on the deployed site.
+	route_base=$(jq -r ".\"$key\".routeBasePath // empty" "$CONFIG_FILE")
+	if [ -z "$route_base" ]; then
+		if [ "$key" = "project-quiver" ]; then
+			route_base="quiver"
+		else
+			route_base="$key"
+		fi
+	fi
+
+	asset_static_path="static/$route_base"
+	echo "  Mirroring static assets to /$route_base/..."
+	rm -rf "$asset_static_path"
+	mkdir -p "$asset_static_path"
+	rsync -a \
+		--exclude='*.md' \
+		--exclude='*.mdx' \
+		--exclude='_category_.json' \
+		--exclude='.DS_Store' \
+		"$target_path/" "$asset_static_path/"
+
 	# Patch known upstream links that do not resolve cleanly in the website's
 	# Docusaurus route structure after import.
 	if [ "$key" = "project-quiver" ] && [ -f "$target_path/index.md" ]; then


### PR DESCRIPTION
## Summary
- exclude imported Quiver `Archive/` docs from Docusaurus builds
- mirror non-doc assets from imported external docs into the Docusaurus static route path
- fixes raw HTML image tags and binary asset links that keep relative URLs instead of being rewritten into hashed assets

## Why
Today’s staging deploy failed on an archived SDK guide image. The archive should not be part of the public docs build at all, so the website now ignores `**/Archive/**` for the Quiver docs plugin.

Separately, Quiver structural assembly docs use raw HTML `<img src="assets/...">`. Docusaurus leaves those URLs relative, so staging currently requests paths like `/quiver/Dev-Kit-Guides/Assembly-Guides/assets/images/structural/1111.png` and gets 404. Mirroring imported assets under the route path fixes that.

## Verification
- local import confirmed upstream archive still contains the broken `Images/Quiver Payload Network.png` reference
- local Docusaurus build succeeds anyway because archive docs are excluded
- verified no archive route is generated
- verified build emits `build/quiver/Dev-Kit-Guides/Assembly-Guides/assets/images/structural/1111.png`
