### PR TITLE
Fix imported Quiver bounty image paths

### DIFF
--- a/scripts/import-external-docs.sh
+++ b/scripts/import-external-docs.sh
@@ -65,6 +65,14 @@ for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
 		-e 's/<img \([^>]*[^/]\)>/<img \1 \/>/g' \
 		{} \;
 
+	# Project Quiver docs can reference repo-root bounty assets from inside docs/.
+	# The website imports only docs/, so rewrite those image paths to raw GitHub URLs.
+	if [ "$key" = "project-quiver" ]; then
+		find "$target_path" -name "*.md" -type f -exec $SED_INPLACE \
+			-e 's|](../../task-grant-bounty/|](https://raw.githubusercontent.com/Arrow-air/project-quiver/main/task-grant-bounty/|g' \
+			{} \;
+	fi
+
 	# Move HTML files to static folder (Docusaurus serves these as-is)
 	# Put under static/docs/ so URLs match the /docs/... path
 	static_path="static/docs/$key"


### PR DESCRIPTION
## Summary\n- Rewrite imported Project Quiver markdown image paths that point outside docs/ into raw GitHub URLs\n- Keeps upstream Project Quiver docs unchanged while making the website import self-contained enough for Docusaurus\n\n## Why\nThe staging deploy failed because Project Quiver docs reference repo-root task-grant-bounty assets from inside docs/. The website import only sparse-checks out docs/, so Docusaurus could not resolve those relative images.\n\n## Test\n- npm run import-docs\n- npm run build\n