### PR TITLE
Doc UI polish: heading hierarchy, category index layout, card swizzle

### DIFF
--- a/docs/cards-test.mdx
+++ b/docs/cards-test.mdx
@@ -3,10 +3,22 @@
 ## Image only
 
 <Cards cols={2}>
-  <Card title="Project Quiver" href="/quiver" image="/img/quiver-card-image-01.png">
+  <Card
+    title="Project Quiver"
+    href="/quiver"
+    imageDarkUnhover="/img/card-quiver_dark-unhover.png"
+    imageLightUnhover="/img/card-quiver_light-unhover.png"
+    imageHover="/img/card-quiver_hover.png"
+  >
     Our open source quadcopter platform for autonomous aerial mobility.
   </Card>
-  <Card title="Flight Tracking" href="/flight-tracking" image="/img/spearhead-first-version.png">
+  <Card
+    title="Project Spearhead"
+    href="/spearhead"
+    imageDarkUnhover="/img/card-spearhead_dark-unhover.png"
+    imageLightUnhover="/img/card-spearhead_light-unhover.png"
+    imageHover="/img/card-spearhead_dark-hover.png"
+  >
     Real-time flight data, telemetry analysis, and route visualisation.
   </Card>
 </Cards>
@@ -19,15 +31,19 @@
   <Card
     title="Project Quiver"
     href="/quiver"
-    image="/img/quiver-card-image-01.png"
+    imageDarkUnhover="/img/card-quiver_dark-unhover.png"
+    imageLightUnhover="/img/card-quiver_light-unhover.png"
+    imageHover="/img/card-quiver_hover.png"
     icon={<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="currentColor"><path d="M2 3V20H22V6H13L10 3H2Z" stroke="currentColor" strokeWidth="2" strokeMiterlimit="10" strokeLinecap="square" fill="none"></path></g></svg>}
   >
     Our open source quadcopter platform for autonomous aerial mobility.
   </Card>
   <Card
-    title="Flight Tracking"
-    href="/flight-tracking"
-    image="/img/spearhead-first-version.png"
+    title="Project Spearhead"
+    href="/spearhead"
+    imageDarkUnhover="/img/card-spearhead_dark-unhover.png"
+    imageLightUnhover="/img/card-spearhead_light-unhover.png"
+    imageHover="/img/card-spearhead_dark-hover.png"
     icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="square"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>}
   >
     Real-time flight data, telemetry analysis, and route visualisation.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1630,7 +1630,10 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
     padding-left: 0.5rem !important;
     padding-right: 0.5rem !important;
   }
-  .breadcrumbs {
+  /* Breadcrumb sits in <article> (outside .theme-doc-markdown), so without
+     its own padding it lands left of the title. Match the title's 0.5rem
+     inset so the chip background lines up with the content's left edge. */
+  ul.breadcrumbs.breadcrumbs {
     padding-left: 0.5rem !important;
     padding-right: 0.5rem !important;
   }
@@ -1813,6 +1816,11 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 .theme-doc-markdown strong {
   font-weight: 600;
   color: var(--docs-text);
+}
+
+/* Inside table headers, inherit the th's white color instead of forcing dark */
+.theme-doc-markdown th strong {
+  color: inherit;
 }
 
 .theme-doc-markdown em {
@@ -3298,11 +3306,32 @@ video {
   padding: 0;
 }
 
-/* Generated index pages - breadcrumbs match full-width card layout */
+/* Generated index pages (auto-generated category pages):
+   - Outer wrapper keeps upstream's 75% max-width so the right side has the
+     same ghost-TOC space as a regular doc page (.docItemCol).
+   - Direct children are constrained to --docs-content-max-width and
+     auto-centered, mirroring how .theme-doc-markdown sits inside .docItemCol
+     on regular doc pages — so content widths match /quiver/. */
+[class*="generatedIndexPage"] > * {
+  max-width: var(--docs-content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  box-sizing: border-box;
+}
+
 [class*="generatedIndexPage"] [class*="breadcrumbsContainer"] {
+  margin-bottom: 1.25rem;
+}
+
+[class*="generatedIndexPage"] .breadcrumbs,
+[class*="generatedIndexPage"] .pagination-nav {
   max-width: none;
-  margin: 0;
-  padding: 0;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
 }
 
 .breadcrumbs {
@@ -4114,6 +4143,18 @@ a.card--link:hover .card__media-icon {
 .card__content {
   padding: 1rem 1.25rem;
   flex: 1;
+}
+
+/* Invisible hit-area extension below the card. Without it, translating the
+   card up on hover moves the bottom edge above the cursor, dropping hover
+   and causing flicker. The ::after keeps the cursor "inside" the link. */
+a.card--link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -8px;
+  height: 8px;
 }
 
 a.card--link:hover {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -502,7 +502,7 @@ h1, .h1 {
         font-size: 1.75rem!important;
     }
     .theme-doc-markdown h3 {
-        font-size: 1.4rem!important;
+        font-size: 1.55rem!important;
     }
 }
 
@@ -511,7 +511,7 @@ h1, .h1 {
         font-size: 1.5rem!important;
     }
     .theme-doc-markdown h4 {
-        font-size: 1.1rem!important;
+        font-size: 1.4rem!important;
     }
 }
 
@@ -1763,34 +1763,32 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
 /* H3 — Subsection. Sans-serif with subtle underline */
 .theme-doc-markdown h3 {
   font-family: 'Neue Haas Grotesk', sans-serif;
-  font-size: 1.4rem;
-  font-weight: 500;
-  color: var(--docs-text);
+  font-size: 1.55rem;
+  font-weight: 600;
+  color: #000;
   margin: 2.5rem 0 1rem 0;
   padding-bottom: 0.3rem;
   border-bottom: 1px solid var(--docs-border);
 }
 
-/* H4 — Label. Mono uppercase */
+/* H4 — Smaller than H3, bold, slate */
 .theme-doc-markdown h4 {
-  font-family: 'Jetbrainsmono', monospace;
-  font-size: 1.1rem;
+  font-family: 'Neue Haas Grotesk', sans-serif;
+  font-size: 1.4rem;
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
   color: var(--docs-text);
-  margin: 2rem 0 0.75rem 0;
+  margin: 2.5rem 0 0.75rem 0;
 }
 
 /* H5 — Sublabel. Mono uppercase, primary accent */
 .theme-doc-markdown h5 {
-  font-family: 'Jetbrainsmono', monospace;
-  font-size: 12px;
-  font-weight: 600;
+  font-family: 'Neue Haas Grotesk', sans-serif;
+  font-size: 14px;
+  font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--docs-primary);
-  margin: 1.25rem 0 0.375rem 0;
+  margin: 2rem 0 0.375rem 0;
 }
 
 /* H6 — Fine print label */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -3946,7 +3946,7 @@ kbd[class*="searchHint"] {
   box-shadow: none;
   overflow: visible;
   will-change: transform;
-  transition: transform 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94), box-shadow 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94), background-color 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94), border-color 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: transform 0.2s cubic-bezier(0.23, 1, 0.32, 1), box-shadow 0.2s cubic-bezier(0.23, 1, 0.32, 1), background-color 0.2s cubic-bezier(0.23, 1, 0.32, 1), border-color 0.2s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .card::before {
@@ -3960,14 +3960,29 @@ kbd[class*="searchHint"] {
   background-position: left bottom;
   background-size: 8px 130px;
   filter: saturate(0) opacity(0.15);
-  transition: filter 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: filter 0.2s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 a.card--link:hover::before {
   filter: saturate(1) opacity(1);
 }
 
-.cards--cols-3 .card::before {
+.cards .card:not(:has(.card__media-wrapper))::before,
+.row .card:not(:has(.card__media-wrapper))::before {
+  display: none;
+}
+
+.cards .card:not(:has(.card__media-wrapper)),
+.row .card:not(:has(.card__media-wrapper)) {
+  box-shadow: inset 0 -5px 0 rgba(8, 67, 191, 0.15);
+}
+
+.cards a.card--link:not(:has(.card__media-wrapper)):hover,
+.row a.card--link:not(:has(.card__media-wrapper)):hover {
+  box-shadow: inset 0 -5px 0 var(--ifm-color-primary), 0 10px 24px rgba(0, 0, 0, 0.13);
+}
+
+.cards--cols-3 .card:has(.card__media-wrapper)::before {
   background-image: url('/img/card-bayer-90.svg');
   background-size: 8px 90px;
 }
@@ -3999,7 +4014,7 @@ a.card--link:hover::before {
   border-top: 1px solid var(--card-border);
   border-left: 1px solid var(--card-border);
   border-top-left-radius: 6px;
-  transition: background-color 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: background-color 0.2s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .card__media-wrapper::after {
@@ -4017,7 +4032,7 @@ a.card--link:hover::before {
   z-index: 1;
   aspect-ratio: 16 / 9;
   overflow: hidden;
-  transition: background-color 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: background-color 0.2s cubic-bezier(0.23, 1, 0.32, 1);
   border-top: 1px solid var(--card-border);
   border-left: 1px solid var(--card-border);
   border-radius: 0;
@@ -4034,7 +4049,7 @@ a.card--link:hover::before {
   object-fit: cover;
   display: block;
   filter: saturate(0) opacity(0.15);
-  transition: filter 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: filter 0.2s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 a.card--link:hover .card__image {
@@ -4047,7 +4062,7 @@ a.card--link:hover .card__image {
 .card__image--hover {
   filter: none;
   opacity: 0;
-  transition: opacity 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: opacity 0.2s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 a.card--link:hover .card__image--dark-unhover,
@@ -4078,7 +4093,7 @@ a.card--link:hover .card__image--hover { opacity: 1; }
   left: 1.25rem;
   color: var(--docs-primary);
   opacity: 0.5;
-  transition: opacity 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: opacity 0.2s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 a.card--link:hover .card__media-icon {
@@ -4099,14 +4114,19 @@ a.card--link:hover .card__media-icon {
 .card__content {
   padding: 1rem 1.25rem;
   flex: 1;
-  transition: background 0.15s ease;
 }
 
 a.card--link:hover {
   background: var(--card-hover-color);
   border-color: #6D8ED9;
   transform: translateY(-4px);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.13);
+}
+
+a.card--link:active {
+  transform: translateY(-2px) scale(0.98);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+  transition-duration: 0.1s;
 }
 
 a.card--link:hover .card__media,
@@ -4166,12 +4186,12 @@ a.card--link:hover .card__content {
   flex-shrink: 0;
   color: var(--docs-primary);
   opacity: 0.6;
-  transition: opacity 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: opacity 0.2s cubic-bezier(0.23, 1, 0.32, 1), transform 0.2s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 a.card--link:hover .card__title-arrow {
   opacity: 0.9;
-  animation: card-arrow-pulse 0.4s ease-out forwards;
+  animation: card-arrow-pulse 0.3s cubic-bezier(0.23, 1, 0.32, 1) forwards;
 }
 
 .card__body,
@@ -4181,7 +4201,7 @@ a.card--link:hover .card__title-arrow {
   font-size: 14px;
   color: #6a7c95;
   line-height: 1.55;
-  transition: color 0.15s ease;
+  transition: color 0.2s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 a.card--link:hover .card__body,

--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -1,0 +1,72 @@
+import React, {type ReactNode} from 'react';
+import {findFirstSidebarItemLink, useDocById} from '@docusaurus/plugin-content-docs/client';
+import {usePluralForm} from '@docusaurus/theme-common';
+import {translate} from '@docusaurus/Translate';
+import type {Props} from '@theme/DocCard';
+import type {PropSidebarItemCategory, PropSidebarItemLink} from '@docusaurus/plugin-content-docs';
+import {Card} from '@site/src/components/Cards';
+
+const DocIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="square">
+    <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/>
+    <polyline points="13 2 13 9 20 9"/>
+  </svg>
+);
+
+const FolderIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="square">
+    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+  </svg>
+);
+
+function useCategoryItemsPlural() {
+  const {selectMessage} = usePluralForm();
+  return (count: number) =>
+    selectMessage(
+      count,
+      translate({
+        message: '1 item|{count} items',
+        id: 'theme.docs.DocCard.categoryDescription.plurals',
+        description: 'The default description for a category card in the generated index about how many items this category includes',
+      }, {count}),
+    );
+}
+
+function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
+  const href = findFirstSidebarItemLink(item);
+  const categoryItemsPlural = useCategoryItemsPlural();
+  if (!href) return null;
+  return (
+    <Card
+      title={item.label}
+      href={href}
+      titleIcon={<FolderIcon />}
+    >
+      {item.description ?? categoryItemsPlural(item.items.length)}
+    </Card>
+  );
+}
+
+function CardLink({item}: {item: PropSidebarItemLink}): ReactNode {
+  const doc = useDocById(item.docId ?? undefined);
+  return (
+    <Card
+      title={item.label}
+      href={item.href}
+      titleIcon={<DocIcon />}
+    >
+      {item.description ?? doc?.description}
+    </Card>
+  );
+}
+
+export default function DocCard({item}: Props): ReactNode {
+  switch (item.type) {
+    case 'link':
+      return <CardLink item={item} />;
+    case 'category':
+      return <CardCategory item={item} />;
+    default:
+      throw new Error(`unknown item type ${JSON.stringify(item)}`);
+  }
+}

--- a/src/theme/DocCardList/index.tsx
+++ b/src/theme/DocCardList/index.tsx
@@ -1,0 +1,31 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {
+  useCurrentSidebarSiblings,
+  filterDocCardListItems,
+} from '@docusaurus/plugin-content-docs/client';
+import DocCard from '@theme/DocCard';
+import type {Props} from '@theme/DocCardList';
+import {Cards} from '@site/src/components/Cards';
+
+function DocCardListForCurrentSidebarCategory({className}: Props) {
+  const items = useCurrentSidebarSiblings();
+  return <DocCardList items={items} className={className} />;
+}
+
+export default function DocCardList(props: Props): ReactNode {
+  const {items, className} = props;
+  if (!items) {
+    return <DocCardListForCurrentSidebarCategory {...props} />;
+  }
+  const filteredItems = filterDocCardListItems(items);
+  return (
+    <div className={clsx(className)}>
+      <Cards cols={2}>
+        {filteredItems.map((item, index) => (
+          <DocCard key={index} item={item} />
+        ))}
+      </Cards>
+    </div>
+  );
+}


### PR DESCRIPTION
  ## Summary
  
  Three layered improvements to docs presentation.
  
  ### 1. Heading hierarchy (h3–h5)
  - Bumped h3/h4/h5 font sizes for stronger presence on doc pages
  - Switched h4 and h5 from JetBrains Mono to Neue Haas Grotesk so bold weights actually read as bold
  - Tightened color + weight gradient: **h3** (`#000`, 600, 1.55rem, with underline) → **h4** (slate, 700, 1.4rem) → **h5** (primary, 700, 14px uppercase)
  - Bumped h4 and h5 top margins for clearer section breaks
  
  ### 2. Category index layout + breadcrumb / table polish
  - Swizzled `DocCardList` to replace Docusaurus's upstream `.row/.col--6` negative-margin grid with our `.cards` CSS grid, so auto-generated category index pages (e.g. `/quiver/category/manufacturing`) no
  longer bleed past the title
  - Styled `generated-index` direct children to match `/quiver/`'s content width (860px column inside the 75% ghost-TOC wrapper)
  - Stripped duplicate auto-centering on breadcrumbs and pagination inside generated-index pages so they share the column's edges
  - Added invisible `::after` hit-area below card links so the `translateY(-4px)` hover doesn't flicker at the card's bottom edge
  - Kept `<strong>` inside `<th>` inheriting the header's white text
  - Raised mobile breadcrumb specificity so the `0.5rem` padding wins source-order against the global rule, aligning the chip background with the title's left edge at `<996px`

  ### 3. DocCard swizzle + hover styling
  - Added a `DocCard` swizzle so auto-generated category index cards inherit the site's card styles (blue strip, hover transitions, distinct SVG icons for link vs category items)
  - Updated `cards-test` page and tightened hover states in `custom.css`

  ## Test plan
  - [ ] `/docs/kitchen-sink` — heading hierarchy reads cleanly h1 → h6
  - [ ] `/quiver/category/manufacturing` (or any generated category index) — cards align inside content column, breadcrumbs flush left, no bleed past title
  - [ ] `/docs/cards-test` — DocCard hover / blue strip / link-vs-category icons all render
  - [ ] Mobile (<996px) — breadcrumb chip aligns with title left edge
  - [ ] Spot-check a real doc page with h3/h4/h5 mixed for spacing rhythm