### PR TITLE
chore: ignore imported Quiver static assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ static/dao.html
 # Imported external docs (pulled at build time via scripts/import-external-docs.sh or S3 sync in CI)
 docs/project-quiver/
 static/docs/project-quiver/
+static/quiver/
 
 # Shared about-arrow symlinks in multi-instance doc dirs
 docs-quiver/about-arrow


### PR DESCRIPTION
## Summary
- ignore `static/quiver/`, which is generated by the Quiver docs import script
- keeps imported Quiver static assets out of the website repo working tree

## Testing
- `git status --ignored` shows `static/quiver/` ignored