### PR TITLE
chore: group Dependabot GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- group GitHub Actions Dependabot updates into one monthly PR, matching the npm grouping behavior

## Notes
- This should prevent Dependabot from opening separate PRs for each action update.
- Existing open Dependabot action PRs may need to be closed/recreated after this merges.
