### PR TITLE
fix: correct editUrl for multi-instance docs plugins

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -87,7 +87,9 @@ const config = {
       routeBasePath: 'quiver',
       sidebarPath: require.resolve('./sidebars-quiver.js'),
       exclude: ['**/Archive/**'],
-      editUrl: 'https://github.com/Arrow-air/project-quiver/edit/main/docs/',
+      // Upstream repo holds files under docs/<docPath>, not docs/project-quiver/<docPath>.
+      editUrl: (/** @type {{docPath: string}} */ { docPath }) =>
+        `https://github.com/Arrow-air/project-quiver/edit/main/docs/${docPath}`,
       showLastUpdateTime: true,
     }],
     ['@docusaurus/plugin-content-docs', {
@@ -95,7 +97,8 @@ const config = {
       path: 'docs-spearhead',
       routeBasePath: 'spearhead',
       sidebarPath: require.resolve('./sidebars-spearhead.js'),
-      editUrl: 'https://github.com/Arrow-air/website/edit/staging/docs-spearhead/',
+      editUrl: (/** @type {{docPath: string}} */ { docPath }) =>
+        `https://github.com/Arrow-air/website/edit/staging/docs-spearhead/${docPath}`,
       showLastUpdateTime: true,
     }],
     ['@docusaurus/plugin-content-docs', {
@@ -103,7 +106,8 @@ const config = {
       path: 'docs-flight-tracking',
       routeBasePath: 'flight-tracking',
       sidebarPath: require.resolve('./sidebars-flight-tracking.js'),
-      editUrl: 'https://github.com/Arrow-air/website/edit/staging/docs-flight-tracking/',
+      editUrl: (/** @type {{docPath: string}} */ { docPath }) =>
+        `https://github.com/Arrow-air/website/edit/staging/docs-flight-tracking/${docPath}`,
       showLastUpdateTime: true,
     }],
     ['@docusaurus/plugin-content-docs', {
@@ -111,7 +115,8 @@ const config = {
       path: 'docs-bounty',
       routeBasePath: 'bounty',
       sidebarPath: require.resolve('./sidebars-bounty.js'),
-      editUrl: 'https://github.com/Arrow-air/website/edit/staging/docs-bounty/',
+      editUrl: (/** @type {{docPath: string}} */ { docPath }) =>
+        `https://github.com/Arrow-air/website/edit/staging/docs-bounty/${docPath}`,
       showLastUpdateTime: true,
     }],
   ],
@@ -130,7 +135,7 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           exclude: ['**/project-quiver/**'], // served by the separate quiver plugin instance
           showLastUpdateTime: true,
-          editUrl: ({ docPath }) => {
+          editUrl: (/** @type {{docPath: string}} */ { docPath }) => {
             // Check if this doc is from an external repo
             for (const [folder, config] of Object.entries(externalDocs)) {
               if (docPath.startsWith(`${folder}/`)) {

--- a/src/theme/DocItem/Layout/MarkdownToggle.tsx
+++ b/src/theme/DocItem/Layout/MarkdownToggle.tsx
@@ -193,14 +193,16 @@ export default function MarkdownToggle({children}: Props): ReactNode {
     if (!rawContent && editUrl) {
       setFetchError(null);
       fetchPromise = (async () => {
+        const rawUrl = editUrlToRawUrl(editUrl);
         try {
-          const rawUrl = editUrlToRawUrl(editUrl);
           const resp = await fetch(rawUrl);
           if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
           const text = await resp.text();
           setRawContent(text);
         } catch (e) {
-          setFetchError(`Failed to fetch source: ${e instanceof Error ? e.message : String(e)}`);
+          const reason = e instanceof Error ? e.message : String(e);
+          console.error('[MarkdownToggle] fetch failed', {rawUrl, editUrl, reason});
+          setFetchError(`Failed to fetch ${rawUrl}\n${reason}`);
         }
       })();
     }


### PR DESCRIPTION
## Summary
  When `editUrl` is a string, Docusaurus appends the site-relative source path to it. For multi-instance docs plugin configs (`quiver`, `spearhead`,
  `flight-tracking`, `bounty`), that duplicated the docs-dir prefix:
  
  edit/main/docs/  +  docs/project-quiver/Operations/Pilot-Handbook.md
  → edit/main/docs/docs/project-quiver/Operations/Pilot-Handbook.md   ← broken

  `MarkdownToggle` then derived a raw URL from that broken edit URL and 404'd silently, so the "view markdown source" toggle showed nothing on those plugins' pages.

  ### Changes
  - Switch each of the 4 plugin instances to the **function** form of `editUrl` so Docusaurus passes a plugin-relative `docPath` and the URL join happens in one
  place.
  - Surface the failing raw URL in both the on-page error message and `console.error('[MarkdownToggle] fetch failed', …)` so similar 404s aren't quiet next time.

  The classic preset's `docs` (main `docs/` folder) already used the function form and was unaffected.

  ## Test plan
  - [ ] On a nested page in each plugin (`/quiver/Operations/Pilot-Handbook`, `/spearhead/...`, `/flight-tracking/...`, `/bounty/about`), click the markdown source
  toggle and verify the raw markdown renders
  - [ ] Verify "Edit this page" / "View on GitHub" links point to the correct files on GitHub
  - [ ] Force-fail a fetch (e.g. typo a docPath in DevTools) and confirm the error UI now shows the full raw URL