### PR TITLE
Respect OS color scheme and de-jank theme switching  

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,6 +76,7 @@ const config = {
     require.resolve('./src/js/sidebarScrollPosition.js'),
     require.resolve('./src/js/routeClasses.js'),
     require.resolve('./src/js/sidebarPoweredBy.js'),
+    require.resolve('./src/js/themeTransition.js'),
   ],
 
   plugins: [
@@ -183,7 +184,7 @@ const config = {
       colorMode: {
         defaultMode: 'light',
         disableSwitch: false,
-        respectPrefersColorScheme: false,
+        respectPrefersColorScheme: true,
       },
       docs: {
         sidebar: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -62,6 +62,13 @@
    BASE STYLES
    ========================================================================== */
 
+html.theme-switching,
+html.theme-switching *,
+html.theme-switching *::before,
+html.theme-switching *::after {
+    transition: none !important;
+}
+
 html, body {
     height: 100%;
     color: var(--bs-dark);

--- a/src/js/themeTransition.js
+++ b/src/js/themeTransition.js
@@ -1,0 +1,13 @@
+if (typeof window !== 'undefined') {
+  const html = document.documentElement;
+  const CLASS = 'theme-switching';
+
+  const observer = new MutationObserver(() => {
+    html.classList.add(CLASS);
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => html.classList.remove(CLASS));
+    });
+  });
+
+  observer.observe(html, {attributes: true, attributeFilter: ['data-theme']});
+}


### PR DESCRIPTION
## Summary
  - Enable Docusaurus's `respectPrefersColorScheme` so first-time visitors land in their OS-preferred theme. The manual navbar toggle still overrides and persists per-user in `localStorage`.
  - Add a small client module that watches the `data-theme` attribute on `<html>` and toggles a transient `.theme-switching` class for one frame.
  - Add a CSS rule that disables transitions while `.theme-switching` is present, removing the staggered fade from components that animate `background-color` / `border-color` / `color`.

  ## Test plan
  - [ ] Set macOS to Dark mode, open the docs in a fresh browser profile (or cleared `localStorage`) — should load in dark.
  - [ ] Set macOS to Light mode, reload — should load in light.
  - [ ] Use the navbar toggle; reload and confirm choice persists regardless of OS setting.
  - [ ] Toggle theme back and forth — components swap instantly with no visible animation lag.
  - [ ] Hover/transform animations elsewhere still feel normal.