### PR TITLE
fix: resolve docs sidebar font-family cascade flicker (#154)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -930,7 +930,7 @@ h1, .h1 {
 ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link,
 ul.theme-doc-sidebar-menu > [data-sidebar-category] > li > .menu__list-item-collapsible .menu__link,
 .theme-doc-sidebar-menu > .theme-doc-sidebar-item-link-level-1 > .menu__link {
-  font-family: 'Jetbrainsmono', 'Departure Mono', monospace !important;
+  font-family: 'Neue Haas Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
   font-size: 13px !important;
   font-weight: 500 !important;
   text-transform: uppercase !important;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -936,7 +936,7 @@ ul.theme-doc-sidebar-menu > [data-sidebar-category] > li > .menu__list-item-coll
   text-transform: uppercase !important;
   letter-spacing: 0.04em !important;
   color: #000000 !important;
-  padding: 0.5rem 0.75rem;
+  padding: 0.4rem 0.75rem;
   padding-left: 1.75rem !important;
   position: relative;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -931,7 +931,7 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link,
 ul.theme-doc-sidebar-menu > [data-sidebar-category] > li > .menu__list-item-collapsible .menu__link,
 .theme-doc-sidebar-menu > .theme-doc-sidebar-item-link-level-1 > .menu__link {
   font-family: 'Jetbrainsmono', 'Departure Mono', monospace !important;
-  font-size: 14px !important;
+  font-size: 13px !important;
   font-weight: 500 !important;
   text-transform: uppercase !important;
   letter-spacing: 0.04em !important;

--- a/src/theme/Navbar/DocsNavbar.module.css
+++ b/src/theme/Navbar/DocsNavbar.module.css
@@ -468,7 +468,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 16px;
+  padding: 0px 12px;
   height: 33px;
   margin-top: 8px;
   margin-right: 4px;

--- a/src/theme/Navbar/DocsNavbar.module.css
+++ b/src/theme/Navbar/DocsNavbar.module.css
@@ -477,7 +477,7 @@
   border-radius: 5px 5px 0 0;
   border: 1px solid rgba(0, 0, 0, 0.12);
   border-bottom-color: transparent;
-  font-family: 'Jetbrainsmono', 'Departure Mono', monospace;
+  font-family: 'Neue Haas Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: 0.75rem;
   font-weight: 500;
   letter-spacing: 0.03em;

--- a/src/theme/Navbar/DocsNavbar.module.css
+++ b/src/theme/Navbar/DocsNavbar.module.css
@@ -478,7 +478,7 @@
   border: 1px solid rgba(0, 0, 0, 0.12);
   border-bottom-color: transparent;
   font-family: 'Neue Haas Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   font-weight: 500;
   letter-spacing: 0.03em;
   text-transform: uppercase;


### PR DESCRIPTION
  ## Summary
  - Switch docs sidebar level-1 headings and sub-nav tabs from JetBrains Mono to Neue Haas Grotesk (the base body font), eliminating the cascade flicker on initial render
  - Drop level-1 heading size from 14px to 13px
  - Tighten level-1 vertical padding to 0.4rem
  - Tighten sub-nav tab horizontal padding to 12px and font-size to 0.7rem

  Fixes Issue #154
  
  ## Test plan
  - [ ] Hard-reload docs pages — no font-swap flash on level-1 headings or sub-nav tabs
  - [ ] Sidebar level-1 headings render at the new size/padding in light + dark themes
  - [ ] Sub-nav tabs render at the new size/padding in light + dark themes