### PR TITLE
feat: support local external docs dev watch

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -35,6 +35,7 @@ Flesch
 Flesch-Kincaid
 fract
 frontmatter
+fswatch
 fullwidth
 gatekeeping
 Goodluck
@@ -49,6 +50,7 @@ IEND
 IHDR
 imag
 incentivizing
+inotifywait
 INPLACE
 interoperating
 johnsoncodehk
@@ -76,6 +78,7 @@ openframes
 opensource
 Owlot
 permissionless
+PIDS
 phlgwv
 Photoshop
 PIXKIT
@@ -115,6 +118,7 @@ Videography
 visualisation
 webdevelopers
 Webflow
+webp
 Wireframes
 wordmark
 XFLR

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ $ yarn start
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
+#### Local external docs development
+
+To preview website changes while editing docs in a local checkout of `project-quiver`, point the importer at that checkout and run the local-docs dev script:
+
+```bash
+EXTERNAL_DOCS_LOCAL_PROJECT_QUIVER=/path/to/project-quiver yarn start:local-docs
+```
+
+You can pass either the repository root or its `docs` directory. The script imports once, starts Docusaurus, and watches the local docs for changes so edits are copied into the website dev server without recloning GitHub.
+
 ### Build
 
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To preview website changes while editing docs in a local checkout of `project-qu
 EXTERNAL_DOCS_LOCAL_PROJECT_QUIVER=/path/to/project-quiver yarn start:local-docs
 ```
 
-You can pass either the repository root or its `docs` directory. The script imports once, starts Docusaurus, and watches the local docs for changes so edits are copied into the website dev server without recloning GitHub.
+You can pass either the repository root or its `docs` directory. The script imports once, starts Docusaurus, and watches the local docs for changes so edits are copied into the website dev server without re-cloning GitHub.
 
 ### Build
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "start:local-docs": "node scripts/build-html.js && bash scripts/import-external-docs.sh && (node scripts/build-html.js --watch & bash scripts/import-external-docs.sh --watch & docusaurus start)"
+    "start:local-docs": "bash scripts/start-local-docs.sh"
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "start:local-docs": "node scripts/build-html.js && bash scripts/import-external-docs.sh && (node scripts/build-html.js --watch & bash scripts/import-external-docs.sh --watch & docusaurus start)"
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.1",

--- a/scripts/import-external-docs.sh
+++ b/scripts/import-external-docs.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
+WATCH_MODE=0
+if [ "${1:-}" = "--watch" ]; then
+	WATCH_MODE=1
+fi
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -20,33 +25,90 @@ if ! command -v jq &> /dev/null; then
 	exit 1
 fi
 
-# Detect OS for sed compatibility (macOS uses -i '', Linux uses -i)
-if [[ "$OSTYPE" == "darwin"* ]]; then
-	SED_INPLACE="sed -i ''"
-else
-	SED_INPLACE="sed -i"
-fi
+# sed -i differs between macOS and Linux. Keep this as a function so the
+# empty macOS backup suffix is passed as a real empty argument, not the
+# literal string '' (which creates stray backup files named *.md'').
+sed_inplace() {
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		sed -i '' "$@"
+	else
+		sed -i "$@"
+	fi
+}
 
-# Iterate over each entry in the config
-for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
+local_env_name() {
+	echo "EXTERNAL_DOCS_LOCAL_$1" | tr '[:lower:]' '[:upper:]' | sed 's/[^A-Z0-9_]/_/g'
+}
+
+local_source_for_key() {
+	local key="$1"
+	local env_name
+	env_name="$(local_env_name "$key")"
+	local env_value="${!env_name:-}"
+
+	if [ -n "$env_value" ]; then
+		echo "$env_value"
+		return
+	fi
+
+	jq -r ".\"$key\".localPath // \"\"" "$CONFIG_FILE"
+}
+
+resolved_docs_source() {
+	local configured_path="$1"
+	local docs_path="$2"
+
+	if [ -d "$configured_path/$docs_path" ]; then
+		echo "$configured_path/$docs_path"
+	elif [ -d "$configured_path" ]; then
+		echo "$configured_path"
+	else
+		echo "Error: Local docs path does not exist: $configured_path" >&2
+		return 1
+	fi
+}
+
+source_fingerprint() {
+	local source_dir="$1"
+	# Content-hash only files that participate in the import. This is portable and
+	# avoids requiring fswatch/inotifywait for local development.
+	find "$source_dir" -type f \
+		! -name '.DS_Store' \
+		! -name 'mkdocs.yaml' \
+		! -name 'mkdocs.yml' \
+		-exec shasum {} + 2>/dev/null | sort | shasum | awk '{print $1}'
+}
+
+import_key() {
+	local key="$1"
+	local repo branch docs_path sidebar_label sidebar_position target_path
 	repo=$(jq -r ".\"$key\".repo" "$CONFIG_FILE")
 	branch=$(jq -r ".\"$key\".branch // \"main\"" "$CONFIG_FILE")
 	docs_path=$(jq -r ".\"$key\".docsPath // \"docs\"" "$CONFIG_FILE")
 	sidebar_label=$(jq -r ".\"$key\".sidebarLabel // \"$key\"" "$CONFIG_FILE")
 	sidebar_position=$(jq -r ".\"$key\".sidebarPosition // 99" "$CONFIG_FILE")
-
 	target_path=$(jq -r ".\"$key\".targetPath // \"docs/$key\"" "$CONFIG_FILE")
 
-	echo "Importing docs from $repo ($branch)..."
+	local configured_local_source source_dir tmp_dir
+	configured_local_source="$(local_source_for_key "$key")"
+	tmp_dir=""
 
-	# Create temp dir and clone with sparse checkout
-	tmp_dir=$(mktemp -d)
-	git clone --depth 1 --branch "$branch" --filter=blob:none --sparse \
-		"https://github.com/$repo.git" "$tmp_dir"
+	if [ -n "$configured_local_source" ]; then
+		source_dir="$(resolved_docs_source "$configured_local_source" "$docs_path")"
+		echo "Importing docs from local path $source_dir..."
+	else
+		echo "Importing docs from $repo ($branch)..."
 
-	cd "$tmp_dir"
-	git sparse-checkout set "$docs_path"
-	cd "$PROJECT_ROOT"
+		# Create temp dir and clone with sparse checkout
+		tmp_dir=$(mktemp -d)
+		git clone --depth 1 --branch "$branch" --filter=blob:none --sparse \
+			"https://github.com/$repo.git" "$tmp_dir"
+
+		cd "$tmp_dir"
+		git sparse-checkout set "$docs_path"
+		cd "$PROJECT_ROOT"
+		source_dir="$tmp_dir/$docs_path"
+	fi
 
 	# Remove old docs and create fresh target directory
 	rm -rf "$target_path"
@@ -54,19 +116,22 @@ for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
 
 	# Copy everything except excluded files
 	rsync -av --exclude='.DS_Store' --exclude='mkdocs.yaml' --exclude='mkdocs.yml' \
-		"$tmp_dir/$docs_path/" "$target_path/"
+		"$source_dir/" "$target_path/"
 
 	# Fix MDX compatibility issues in markdown files
 	echo "  Fixing MDX compatibility..."
 
-	find "$target_path" -name "*.md" -type f -exec $SED_INPLACE \
-		-e 's/<br>/<br\/>/g' \
-		-e 's/<hr>/<hr\/>/g' \
-		-e 's/<img \([^>]*[^/]\)>/<img \1 \/>/g' \
-		{} \;
+	find "$target_path" -name "*.md" -type f | while read -r mdfile; do
+		sed_inplace \
+			-e 's/<br>/<br\/>/g' \
+			-e 's/<hr>/<hr\/>/g' \
+			-e 's/<img \([^>]*[^/]\)>/<img \1 \/>/g' \
+			"$mdfile"
+	done
 
 	# Move HTML files to static folder (Docusaurus serves these as-is)
 	# Put under static/docs/ so URLs match the /docs/... path
+	local static_path
 	static_path="static/docs/$key"
 
 	# Clean up old static folder
@@ -76,7 +141,8 @@ for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
 	mkdir -p "$static_path"
 
 	# Find and move HTML files, preserving directory structure
-	find "$target_path" -name "*.html" -type f | while read html_file; do
+	find "$target_path" -name "*.html" -type f | while read -r html_file; do
+		local rel_path rel_dir
 		rel_path="${html_file#$target_path/}"
 		rel_dir=$(dirname "$rel_path")
 
@@ -87,10 +153,11 @@ for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
 
 	# Update links in markdown files to point to static folder
 	echo "  Updating HTML links in markdown files..."
-	find "$target_path" \( -name "*.md" -o -name "*.mdx" \) -type f | while read mdfile; do
+	find "$target_path" \( -name "*.md" -o -name "*.mdx" \) -type f | while read -r mdfile; do
+		local md_rel_dir
 		md_rel_dir=$(dirname "${mdfile#$target_path/}")
 
-		$SED_INPLACE \
+		sed_inplace \
 			-e "s|\./assets/\([^)]*\.html\)|pathname:///docs/$key/$md_rel_dir/assets/\1|g" \
 			"$mdfile" 2>/dev/null || true
 	done
@@ -99,6 +166,7 @@ for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
 	# raw HTML <img src="..."> tags and links to binary assets keep their
 	# relative URLs. Mirror imported non-doc assets under the public route so
 	# those relative URLs resolve on the deployed site.
+	local route_base asset_static_path
 	route_base=$(jq -r ".\"$key\".routeBasePath // empty" "$CONFIG_FILE")
 	if [ -z "$route_base" ]; then
 		if [ "$key" = "project-quiver" ]; then
@@ -124,13 +192,14 @@ for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
 	if [ "$key" = "project-quiver" ] && [ -f "$target_path/index.md" ]; then
 		# Engineering-Reports/_category_.json sets label "Reference / Engineering Reports",
 		# which Docusaurus slugifies to /quiver/category/reference--engineering-reports/.
-		$SED_INPLACE \
+		sed_inplace \
 			-e 's|\[Engineering Reports\](\./Engineering-Reports/)|[Engineering Reports](/quiver/category/reference--engineering-reports/)|g' \
 			"$target_path/index.md" 2>/dev/null || true
 	fi
 
 	# Create _category_.json for sidebar only when importing into the default docs/ subfolder
 	# (not needed for top-level plugin roots specified via targetPath)
+	local custom_target
 	custom_target=$(jq -r ".\"$key\".targetPath // \"\"" "$CONFIG_FILE")
 	if [ -z "$custom_target" ] && [ ! -f "$target_path/_category_.json" ]; then
 		if [ -f "$target_path/index.md" ] || [ -f "$target_path/index.mdx" ]; then
@@ -165,10 +234,63 @@ EOF
 	fi
 
 	# Cleanup
-	rm -rf "$tmp_dir"
+	if [ -n "$tmp_dir" ]; then
+		rm -rf "$tmp_dir"
+	fi
 
 	echo "✓ Imported $repo -> $target_path"
-done
+}
 
-echo ""
-echo "All external docs imported successfully"
+run_import() {
+	for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
+		import_key "$key"
+	done
+
+	echo ""
+	echo "All external docs imported successfully"
+}
+
+run_import
+
+if [ "$WATCH_MODE" -eq 1 ]; then
+	WATCH_KEYS=()
+	WATCH_SOURCES=()
+	WATCH_FINGERPRINTS=()
+
+	for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
+		configured_local_source="$(local_source_for_key "$key")"
+		if [ -n "$configured_local_source" ]; then
+			docs_path=$(jq -r ".\"$key\".docsPath // \"docs\"" "$CONFIG_FILE")
+			source_dir="$(resolved_docs_source "$configured_local_source" "$docs_path")"
+			WATCH_KEYS+=("$key")
+			WATCH_SOURCES+=("$source_dir")
+			WATCH_FINGERPRINTS+=("$(source_fingerprint "$source_dir")")
+		fi
+	done
+
+	if [ "${#WATCH_KEYS[@]}" -eq 0 ]; then
+		echo ""
+		echo "No local external docs configured; --watch has nothing to monitor."
+		echo "Set EXTERNAL_DOCS_LOCAL_PROJECT_QUIVER=/path/to/project-quiver or /path/to/project-quiver/docs."
+		exit 0
+	fi
+
+	interval="${EXTERNAL_DOCS_WATCH_INTERVAL:-2}"
+	echo ""
+	echo "Watching local external docs for changes every ${interval}s..."
+
+	while true; do
+		sleep "$interval"
+		for index in "${!WATCH_KEYS[@]}"; do
+			key="${WATCH_KEYS[$index]}"
+			source_dir="${WATCH_SOURCES[$index]}"
+			new_fingerprint="$(source_fingerprint "$source_dir")"
+			if [ "$new_fingerprint" != "${WATCH_FINGERPRINTS[$index]}" ]; then
+				echo ""
+				echo "Change detected in $source_dir; re-importing $key..."
+				import_key "$key"
+				WATCH_FINGERPRINTS[$index]="$new_fingerprint"
+			fi
+		done
+	done
+fi

--- a/scripts/import-external-docs.sh
+++ b/scripts/import-external-docs.sh
@@ -14,6 +14,9 @@ set -euo pipefail
 #
 # The environment variable name is generated from the external-docs.json key:
 # project-quiver -> EXTERNAL_DOCS_LOCAL_PROJECT_QUIVER.
+#
+# Local paths are intentionally env-var only, not external-docs.json config, so
+# nobody accidentally commits a machine-specific path.
 
 WATCH_MODE=0
 if [ "${1:-}" = "--watch" ]; then
@@ -52,46 +55,72 @@ local_env_name() {
 	echo "EXTERNAL_DOCS_LOCAL_$1" | tr '[:lower:]' '[:upper:]' | sed 's/[^A-Z0-9_]/_/g'
 }
 
-# Return the optional local source path for a docs key.
-# Priority:
-#   1. Environment variable, useful for local one-off testing
-#   2. external-docs.json localPath, useful if we ever want a checked-in default
+# Return the optional local source path for a docs key. This only reads an
+# environment variable so local machine paths never end up in external-docs.json.
 local_source_for_key() {
 	local key="$1"
 	local env_name
 	env_name="$(local_env_name "$key")"
 
-	if [ -n "${!env_name:-}" ]; then
-		echo "${!env_name}"
-		return
-	fi
-
-	jq -r ".\"$key\".localPath // \"\"" "$CONFIG_FILE"
+	echo "${!env_name:-}"
 }
 
 # Accept either a repo root (/path/to/project-quiver) or the docs folder itself
-# (/path/to/project-quiver/docs).
+# (/path/to/project-quiver/docs). Refuse arbitrary folders that do not look like
+# a Docusaurus docs tree; this prevents accidentally importing ~/Documents.
 resolve_docs_source() {
 	local configured_path="$1"
 	local docs_path="$2"
+	local source_dir
 
 	if [ -d "$configured_path/$docs_path" ]; then
-		echo "$configured_path/$docs_path"
+		source_dir="$configured_path/$docs_path"
 	elif [ -d "$configured_path" ]; then
-		echo "$configured_path"
+		source_dir="$configured_path"
 	else
 		echo "Error: Local docs path does not exist: $configured_path" >&2
 		return 1
 	fi
+
+	if ! looks_like_docs_tree "$source_dir"; then
+		echo "Error: Local docs path does not look like a docs folder: $source_dir" >&2
+		echo "Expected markdown/MDX docs or _category_.json. Pass the repo root or its docs folder." >&2
+		return 1
+	fi
+
+	echo "$source_dir"
 }
 
-# Hash the source tree so watch mode can notice changes without extra tools like
-# fswatch/inotifywait. This is simple and portable, but intentionally not magic:
-# every few seconds we hash the docs files and compare with the previous hash.
+looks_like_docs_tree() {
+	local source_dir="$1"
+	find "$source_dir" -maxdepth 3 -type f \( \
+		-name '*.md' -o \
+		-name '*.mdx' -o \
+		-name '_category_.json' \
+	\) -print -quit | grep -q .
+}
+
+# Hash the files that affect the docs preview so watch mode can notice changes
+# without extra tools like fswatch/inotifywait. Do not hash heavy CAD archives,
+# STEP files, zips, etc. every two seconds; importing will still copy those assets
+# when a watched docs/content file changes.
 source_fingerprint() {
 	local source_dir="$1"
 
-	find "$source_dir" -type f \
+	find "$source_dir" -type f \( \
+		-name '*.md' -o \
+		-name '*.mdx' -o \
+		-name '*.html' -o \
+		-name '*.json' -o \
+		-name '*.yml' -o \
+		-name '*.yaml' -o \
+		-name '*.png' -o \
+		-name '*.jpg' -o \
+		-name '*.jpeg' -o \
+		-name '*.gif' -o \
+		-name '*.webp' -o \
+		-name '*.svg' \
+	\) \
 		! -name '.DS_Store' \
 		! -name 'mkdocs.yaml' \
 		! -name 'mkdocs.yml' \

--- a/scripts/import-external-docs.sh
+++ b/scripts/import-external-docs.sh
@@ -1,33 +1,43 @@
 #!/bin/bash
 set -euo pipefail
 
+# Import documentation from external repos into this Docusaurus site.
+#
+# Normal website builds clone the configured GitHub repo/branch from
+# external-docs.json, copy its docs into this repo, then let Docusaurus build
+# the copied files.
+#
+# Local development can skip the GitHub clone and copy from a local checkout:
+#
+#   EXTERNAL_DOCS_LOCAL_PROJECT_QUIVER=/path/to/project-quiver \
+#     bash scripts/import-external-docs.sh --watch
+#
+# The environment variable name is generated from the external-docs.json key:
+# project-quiver -> EXTERNAL_DOCS_LOCAL_PROJECT_QUIVER.
+
 WATCH_MODE=0
 if [ "${1:-}" = "--watch" ]; then
 	WATCH_MODE=1
 fi
 
-# Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+CONFIG_FILE="$PROJECT_ROOT/external-docs.json"
 
 cd "$PROJECT_ROOT"
-
-CONFIG_FILE="$PROJECT_ROOT/external-docs.json"
 
 if [ ! -f "$CONFIG_FILE" ]; then
 	echo "Error: Config file not found: $CONFIG_FILE"
 	exit 1
 fi
 
-# Check if jq is available
 if ! command -v jq &> /dev/null; then
 	echo "Error: jq is required but not installed. Install with: brew install jq (macOS) or apt-get install jq (Linux)"
 	exit 1
 fi
 
-# sed -i differs between macOS and Linux. Keep this as a function so the
-# empty macOS backup suffix is passed as a real empty argument, not the
-# literal string '' (which creates stray backup files named *.md'').
+# macOS and Linux spell in-place sed differently. Hiding that here keeps the
+# actual import steps readable.
 sed_inplace() {
 	if [[ "$OSTYPE" == "darwin"* ]]; then
 		sed -i '' "$@"
@@ -36,25 +46,32 @@ sed_inplace() {
 	fi
 }
 
+# Convert a docs key like "project-quiver" into an env var name like
+# "EXTERNAL_DOCS_LOCAL_PROJECT_QUIVER".
 local_env_name() {
 	echo "EXTERNAL_DOCS_LOCAL_$1" | tr '[:lower:]' '[:upper:]' | sed 's/[^A-Z0-9_]/_/g'
 }
 
+# Return the optional local source path for a docs key.
+# Priority:
+#   1. Environment variable, useful for local one-off testing
+#   2. external-docs.json localPath, useful if we ever want a checked-in default
 local_source_for_key() {
 	local key="$1"
 	local env_name
 	env_name="$(local_env_name "$key")"
-	local env_value="${!env_name:-}"
 
-	if [ -n "$env_value" ]; then
-		echo "$env_value"
+	if [ -n "${!env_name:-}" ]; then
+		echo "${!env_name}"
 		return
 	fi
 
 	jq -r ".\"$key\".localPath // \"\"" "$CONFIG_FILE"
 }
 
-resolved_docs_source() {
+# Accept either a repo root (/path/to/project-quiver) or the docs folder itself
+# (/path/to/project-quiver/docs).
+resolve_docs_source() {
 	local configured_path="$1"
 	local docs_path="$2"
 
@@ -68,10 +85,12 @@ resolved_docs_source() {
 	fi
 }
 
+# Hash the source tree so watch mode can notice changes without extra tools like
+# fswatch/inotifywait. This is simple and portable, but intentionally not magic:
+# every few seconds we hash the docs files and compare with the previous hash.
 source_fingerprint() {
 	local source_dir="$1"
-	# Content-hash only files that participate in the import. This is portable and
-	# avoids requiring fswatch/inotifywait for local development.
+
 	find "$source_dir" -type f \
 		! -name '.DS_Store' \
 		! -name 'mkdocs.yaml' \
@@ -79,28 +98,26 @@ source_fingerprint() {
 		-exec shasum {} + 2>/dev/null | sort | shasum | awk '{print $1}'
 }
 
-import_key() {
+# Copy source docs into the website repo. The source can be either:
+#   - a local checkout (for fast edit/preview loops), or
+#   - a temporary sparse clone from GitHub (for normal builds/deploys).
+copy_source_docs() {
 	local key="$1"
-	local repo branch docs_path sidebar_label sidebar_position target_path
-	repo=$(jq -r ".\"$key\".repo" "$CONFIG_FILE")
-	branch=$(jq -r ".\"$key\".branch // \"main\"" "$CONFIG_FILE")
-	docs_path=$(jq -r ".\"$key\".docsPath // \"docs\"" "$CONFIG_FILE")
-	sidebar_label=$(jq -r ".\"$key\".sidebarLabel // \"$key\"" "$CONFIG_FILE")
-	sidebar_position=$(jq -r ".\"$key\".sidebarPosition // 99" "$CONFIG_FILE")
-	target_path=$(jq -r ".\"$key\".targetPath // \"docs/$key\"" "$CONFIG_FILE")
+	local repo="$2"
+	local branch="$3"
+	local docs_path="$4"
+	local target_path="$5"
+	local local_source="$6"
+	local source_dir
+	local tmp_dir=""
 
-	local configured_local_source source_dir tmp_dir
-	configured_local_source="$(local_source_for_key "$key")"
-	tmp_dir=""
-
-	if [ -n "$configured_local_source" ]; then
-		source_dir="$(resolved_docs_source "$configured_local_source" "$docs_path")"
+	if [ -n "$local_source" ]; then
+		source_dir="$(resolve_docs_source "$local_source" "$docs_path")"
 		echo "Importing docs from local path $source_dir..."
 	else
 		echo "Importing docs from $repo ($branch)..."
 
-		# Create temp dir and clone with sparse checkout
-		tmp_dir=$(mktemp -d)
+		tmp_dir="$(mktemp -d)"
 		git clone --depth 1 --branch "$branch" --filter=blob:none --sparse \
 			"https://github.com/$repo.git" "$tmp_dir"
 
@@ -110,17 +127,23 @@ import_key() {
 		source_dir="$tmp_dir/$docs_path"
 	fi
 
-	# Remove old docs and create fresh target directory
 	rm -rf "$target_path"
 	mkdir -p "$target_path"
 
-	# Copy everything except excluded files
 	rsync -av --exclude='.DS_Store' --exclude='mkdocs.yaml' --exclude='mkdocs.yml' \
 		"$source_dir/" "$target_path/"
 
-	# Fix MDX compatibility issues in markdown files
-	echo "  Fixing MDX compatibility..."
+	if [ -n "$tmp_dir" ]; then
+		rm -rf "$tmp_dir"
+	fi
+}
 
+# Docusaurus uses MDX, which is stricter than plain Markdown. Patch a few common
+# HTML tags from imported docs so they do not break the Docusaurus build.
+fix_mdx_compatibility() {
+	local target_path="$1"
+
+	echo "  Fixing MDX compatibility..."
 	find "$target_path" -name "*.md" -type f | while read -r mdfile; do
 		sed_inplace \
 			-e 's/<br>/<br\/>/g' \
@@ -128,55 +151,56 @@ import_key() {
 			-e 's/<img \([^>]*[^/]\)>/<img \1 \/>/g' \
 			"$mdfile"
 	done
+}
 
-	# Move HTML files to static folder (Docusaurus serves these as-is)
-	# Put under static/docs/ so URLs match the /docs/... path
-	local static_path
-	static_path="static/docs/$key"
+# Docusaurus should not compile generated HTML files like interactive BOMs as
+# docs pages. Move them under static/docs/... where they are served as raw files.
+move_html_to_static() {
+	local key="$1"
+	local target_path="$2"
+	local static_path="static/docs/$key"
 
-	# Clean up old static folder
 	rm -rf "$static_path"
-
-	echo "  Moving HTML files to static folder..."
 	mkdir -p "$static_path"
 
-	# Find and move HTML files, preserving directory structure
+	echo "  Moving HTML files to static folder..."
 	find "$target_path" -name "*.html" -type f | while read -r html_file; do
 		local rel_path rel_dir
 		rel_path="${html_file#$target_path/}"
-		rel_dir=$(dirname "$rel_path")
+		rel_dir="$(dirname "$rel_path")"
 
 		mkdir -p "$static_path/$rel_dir"
 		mv "$html_file" "$static_path/$rel_path"
 		echo "    Moved: $rel_path -> $static_path/$rel_path"
 	done
+}
 
-	# Update links in markdown files to point to static folder
+# After HTML files move to static/docs/..., update Markdown links that pointed at
+# the old relative HTML location.
+update_html_links() {
+	local key="$1"
+	local target_path="$2"
+
 	echo "  Updating HTML links in markdown files..."
 	find "$target_path" \( -name "*.md" -o -name "*.mdx" \) -type f | while read -r mdfile; do
 		local md_rel_dir
-		md_rel_dir=$(dirname "${mdfile#$target_path/}")
+		md_rel_dir="$(dirname "${mdfile#$target_path/}")"
 
 		sed_inplace \
 			-e "s|\./assets/\([^)]*\.html\)|pathname:///docs/$key/$md_rel_dir/assets/\1|g" \
 			"$mdfile" 2>/dev/null || true
 	done
+}
 
-	# Docusaurus processes Markdown image syntax into hashed build assets, but
-	# raw HTML <img src="..."> tags and links to binary assets keep their
-	# relative URLs. Mirror imported non-doc assets under the public route so
-	# those relative URLs resolve on the deployed site.
-	local route_base asset_static_path
-	route_base=$(jq -r ".\"$key\".routeBasePath // empty" "$CONFIG_FILE")
-	if [ -z "$route_base" ]; then
-		if [ "$key" = "project-quiver" ]; then
-			route_base="quiver"
-		else
-			route_base="$key"
-		fi
-	fi
+# Markdown image syntax gets processed by Docusaurus, but raw HTML image tags and
+# binary-file links keep their relative URLs. Mirror non-doc assets under the
+# public route so those URLs still resolve.
+mirror_static_assets() {
+	local key="$1"
+	local target_path="$2"
+	local route_base="$3"
+	local asset_static_path="static/$route_base"
 
-	asset_static_path="static/$route_base"
 	echo "  Mirroring static assets to /$route_base/..."
 	rm -rf "$asset_static_path"
 	mkdir -p "$asset_static_path"
@@ -186,9 +210,14 @@ import_key() {
 		--exclude='_category_.json' \
 		--exclude='.DS_Store' \
 		"$target_path/" "$asset_static_path/"
+}
 
-	# Patch known upstream links that do not resolve cleanly in the website's
-	# Docusaurus route structure after import.
+# Small one-off fixes for imported docs whose links do not quite match this
+# website's Docusaurus route structure.
+patch_known_route_mismatches() {
+	local key="$1"
+	local target_path="$2"
+
 	if [ "$key" = "project-quiver" ] && [ -f "$target_path/index.md" ]; then
 		# Engineering-Reports/_category_.json sets label "Reference / Engineering Reports",
 		# which Docusaurus slugifies to /quiver/category/reference--engineering-reports/.
@@ -196,14 +225,23 @@ import_key() {
 			-e 's|\[Engineering Reports\](\./Engineering-Reports/)|[Engineering Reports](/quiver/category/reference--engineering-reports/)|g' \
 			"$target_path/index.md" 2>/dev/null || true
 	fi
+}
 
-	# Create _category_.json for sidebar only when importing into the default docs/ subfolder
-	# (not needed for top-level plugin roots specified via targetPath)
-	local custom_target
-	custom_target=$(jq -r ".\"$key\".targetPath // \"\"" "$CONFIG_FILE")
-	if [ -z "$custom_target" ] && [ ! -f "$target_path/_category_.json" ]; then
-		if [ -f "$target_path/index.md" ] || [ -f "$target_path/index.mdx" ]; then
-			cat > "$target_path/_category_.json" << EOF
+# If the imported docs folder does not define a Docusaurus category, create a
+# simple one so the docs appear nicely in the sidebar.
+create_default_category_if_needed() {
+	local key="$1"
+	local target_path="$2"
+	local sidebar_label="$3"
+	local sidebar_position="$4"
+	local custom_target="$5"
+
+	if [ -n "$custom_target" ] || [ -f "$target_path/_category_.json" ]; then
+		return
+	fi
+
+	if [ -f "$target_path/index.md" ] || [ -f "$target_path/index.mdx" ]; then
+		cat > "$target_path/_category_.json" << EOF
 {
 	"label": "${sidebar_label}",
 	"position": ${sidebar_position},
@@ -215,9 +253,9 @@ import_key() {
 	}
 }
 EOF
-			echo "  Created _category_.json (linked to index doc)"
-		else
-			cat > "$target_path/_category_.json" << EOF
+		echo "  Created _category_.json (linked to index doc)"
+	else
+		cat > "$target_path/_category_.json" << EOF
 {
 	"label": "${sidebar_label}",
 	"position": ${sidebar_position},
@@ -229,14 +267,41 @@ EOF
 	}
 }
 EOF
-			echo "  Created _category_.json (generated index)"
+		echo "  Created _category_.json (generated index)"
+	fi
+}
+
+# Import one entry from external-docs.json.
+import_key() {
+	local key="$1"
+
+	local repo branch docs_path sidebar_label sidebar_position target_path route_base custom_target local_source
+	repo="$(jq -r ".\"$key\".repo" "$CONFIG_FILE")"
+	branch="$(jq -r ".\"$key\".branch // \"main\"" "$CONFIG_FILE")"
+	docs_path="$(jq -r ".\"$key\".docsPath // \"docs\"" "$CONFIG_FILE")"
+	sidebar_label="$(jq -r ".\"$key\".sidebarLabel // \"$key\"" "$CONFIG_FILE")"
+	sidebar_position="$(jq -r ".\"$key\".sidebarPosition // 99" "$CONFIG_FILE")"
+	target_path="$(jq -r ".\"$key\".targetPath // \"docs/$key\"" "$CONFIG_FILE")"
+	route_base="$(jq -r ".\"$key\".routeBasePath // empty" "$CONFIG_FILE")"
+	custom_target="$(jq -r ".\"$key\".targetPath // \"\"" "$CONFIG_FILE")"
+	local_source="$(local_source_for_key "$key")"
+
+	# Default public route when external-docs.json does not specify one.
+	if [ -z "$route_base" ]; then
+		if [ "$key" = "project-quiver" ]; then
+			route_base="quiver"
+		else
+			route_base="$key"
 		fi
 	fi
 
-	# Cleanup
-	if [ -n "$tmp_dir" ]; then
-		rm -rf "$tmp_dir"
-	fi
+	copy_source_docs "$key" "$repo" "$branch" "$docs_path" "$target_path" "$local_source"
+	fix_mdx_compatibility "$target_path"
+	move_html_to_static "$key" "$target_path"
+	update_html_links "$key" "$target_path"
+	mirror_static_assets "$key" "$target_path" "$route_base"
+	patch_known_route_mismatches "$key" "$target_path"
+	create_default_category_if_needed "$key" "$target_path" "$sidebar_label" "$sidebar_position" "$custom_target"
 
 	echo "✓ Imported $repo -> $target_path"
 }
@@ -250,18 +315,22 @@ run_import() {
 	echo "All external docs imported successfully"
 }
 
+# For normal builds: import once and exit.
 run_import
 
+# For local development: keep watching local source folders and re-import when
+# they change. Only local folders are watched; GitHub-cloned sources are not.
 if [ "$WATCH_MODE" -eq 1 ]; then
 	WATCH_KEYS=()
 	WATCH_SOURCES=()
 	WATCH_FINGERPRINTS=()
 
 	for key in $(jq -r 'keys[]' "$CONFIG_FILE"); do
-		configured_local_source="$(local_source_for_key "$key")"
-		if [ -n "$configured_local_source" ]; then
-			docs_path=$(jq -r ".\"$key\".docsPath // \"docs\"" "$CONFIG_FILE")
-			source_dir="$(resolved_docs_source "$configured_local_source" "$docs_path")"
+		local_source="$(local_source_for_key "$key")"
+		if [ -n "$local_source" ]; then
+			docs_path="$(jq -r ".\"$key\".docsPath // \"docs\"" "$CONFIG_FILE")"
+			source_dir="$(resolve_docs_source "$local_source" "$docs_path")"
+
 			WATCH_KEYS+=("$key")
 			WATCH_SOURCES+=("$source_dir")
 			WATCH_FINGERPRINTS+=("$(source_fingerprint "$source_dir")")
@@ -281,10 +350,12 @@ if [ "$WATCH_MODE" -eq 1 ]; then
 
 	while true; do
 		sleep "$interval"
+
 		for index in "${!WATCH_KEYS[@]}"; do
 			key="${WATCH_KEYS[$index]}"
 			source_dir="${WATCH_SOURCES[$index]}"
 			new_fingerprint="$(source_fingerprint "$source_dir")"
+
 			if [ "$new_fingerprint" != "${WATCH_FINGERPRINTS[$index]}" ]; then
 				echo ""
 				echo "Change detected in $source_dir; re-importing $key..."

--- a/scripts/start-local-docs.sh
+++ b/scripts/start-local-docs.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# Start the Docusaurus dev server plus the helper watchers used during local
+# external-docs development. Keeping this in a script instead of a long
+# package.json one-liner lets us clean up child processes reliably on Ctrl+C.
+
+PIDS=()
+
+cleanup() {
+	if [ "${#PIDS[@]}" -gt 0 ]; then
+		kill "${PIDS[@]}" 2>/dev/null || true
+	fi
+}
+
+trap cleanup EXIT INT TERM
+
+node scripts/build-html.js
+bash scripts/import-external-docs.sh
+
+node scripts/build-html.js --watch &
+PIDS+=("$!")
+
+bash scripts/import-external-docs.sh --watch &
+PIDS+=("$!")
+
+# Keep Docusaurus in the foreground. When it exits, or when Ctrl+C interrupts
+# this script, the trap above stops the background watchers.
+docusaurus start


### PR DESCRIPTION
## Summary\n- allow external docs imports to use a local checkout via EXTERNAL_DOCS_LOCAL_<KEY>\n- add --watch mode that re-imports local external docs when source content changes\n- add yarn start:local-docs and README usage for project-quiver docs prototyping\n\n## Testing\n- bash -n scripts/import-external-docs.sh\n- EXTERNAL_DOCS_LOCAL_PROJECT_QUIVER=/Users/thomas/.openclaw/workspace/project-quiver bash scripts/import-external-docs.sh\n- EXTERNAL_DOCS_LOCAL_PROJECT_QUIVER=/Users/thomas/.openclaw/workspace/project-quiver bash scripts/import-external-docs.sh --watch (verified startup, then killed)\n- bash scripts/import-external-docs.sh --watch\n- git diff --check