### PR TITLE
feat: global docs image zoom

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -87,6 +87,7 @@ const config = {
   ],
 
   plugins: [
+    require.resolve('docusaurus-plugin-image-zoom'),
     excludeProjectQuiverFromMainDocsLoader,
     require.resolve('./plugins/dev-homepage'),
     ['@docusaurus/plugin-content-docs', {
@@ -188,6 +189,13 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      zoom: {
+        selector: '.theme-doc-markdown p:not(td p) > img, .theme-doc-markdown figure > img',
+        background: {
+          light: 'rgba(255, 255, 255, 0.96)',
+          dark: 'rgba(17, 24, 39, 0.96)',
+        },
+      },
       colorMode: {
         defaultMode: 'light',
         disableSwitch: false,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -195,6 +195,16 @@ const config = {
           light: 'rgba(255, 255, 255, 0.96)',
           dark: 'rgba(17, 24, 39, 0.96)',
         },
+        // medium-zoom's `config` object is passed straight through by
+        // docusaurus-plugin-image-zoom to mediumZoom(selector, config).
+        // `margin: 48` insets the zoomed image 48px from each viewport edge.
+        // Do NOT add `container` here — passing a tall scrolling container
+        // (e.g. [class^="docMainContainer"]) makes medium-zoom translate to
+        // the article's geometric center, which is far below the viewport,
+        // so the image animates downward instead of zooming in place.
+        config: {
+          margin: 48,
+        },
       },
       colorMode: {
         defaultMode: 'light',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@easyops-cn/docusaurus-search-local": "^0.44.6",
         "@mdx-js/react": "^3.1.1",
         "clsx": "^2.1.1",
+        "docusaurus-plugin-image-zoom": "^3.0.1",
         "lottie-web": "^5.13.0",
         "motion": "^12.38.0",
         "prism-react-renderer": "^2.4.1",
@@ -8720,6 +8721,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/docusaurus-plugin-image-zoom": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-3.0.1.tgz",
+      "integrity": "sha512-mQrqA99VpoMQJNbi02qkWAMVNC4+kwc6zLLMNzraHAJlwn+HrlUmZSEDcTwgn+H4herYNxHKxveE2WsYy73eGw==",
+      "license": "MIT",
+      "dependencies": {
+        "medium-zoom": "^1.1.0",
+        "validate-peer-dependencies": "^2.2.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/theme-classic": ">=3.0.0"
+      }
+    },
     "node_modules/docusaurus-plugin-redoc": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-2.5.0.tgz",
@@ -12437,6 +12451,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/medium-zoom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.1.0.tgz",
+      "integrity": "sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==",
+      "license": "MIT"
+    },
     "node_modules/memfs": {
       "version": "4.54.0",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.54.0.tgz",
@@ -15196,6 +15216,27 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
+      "license": "MIT",
+      "dependencies": {
+        "path-root-regex": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
@@ -18029,6 +18070,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-package-path": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/resolve-pathname": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
@@ -20100,6 +20153,19 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validate-peer-dependencies": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/validate-peer-dependencies/-/validate-peer-dependencies-2.2.0.tgz",
+      "integrity": "sha512-8X1OWlERjiUY6P6tdeU9E0EwO8RA3bahoOVG7ulOZT5MqgNDUO/BQoVjYiHPcNe+v8glsboZRIw9iToMAA2zAA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-package-path": "^4.0.3",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/value-equal": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@easyops-cn/docusaurus-search-local": "^0.44.6",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
+    "docusaurus-plugin-image-zoom": "^3.0.1",
     "lottie-web": "^5.13.0",
     "motion": "^12.38.0",
     "prism-react-renderer": "^2.4.1",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2456,9 +2456,16 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   text-overflow: ellipsis;
 }
 
+/* Zoom affordance for standalone docs images */
+.theme-doc-markdown p > img,
+.theme-doc-markdown figure > img {
+  cursor: zoom-in;
+}
+
 /* Minimize button — replaces ::after, now functional */
 .image-collapse-btn {
   position: absolute;
+  z-index: 1;
   top: 0;
   right: 0;
   height: 2rem;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2471,6 +2471,17 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   z-index: 9999 !important;
 }
 
+/* Disable medium-zoom on mobile: native pinch-zoom is sufficient there,
+   and the overlay gets in the way. `pointer-events: none` blocks the
+   click handler medium-zoom binds to each img. */
+@media (max-width: 996px) {
+  .theme-doc-markdown p > img,
+  .theme-doc-markdown figure > img {
+    cursor: auto;
+    pointer-events: none;
+  }
+}
+
 /* Minimize button — replaces ::after, now functional */
 .image-collapse-btn {
   position: absolute;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2462,6 +2462,15 @@ ul.theme-doc-sidebar-menu > li > .menu__list-item-collapsible .menu__link::befor
   cursor: zoom-in;
 }
 
+/* medium-zoom: lift overlay + zoomed image above Docusaurus' navbar
+   and sidebar (both use --ifm-z-index-fixed: 200). Without this the
+   dim overlay sits beneath the sidebar and the zoomed image is
+   visually clipped behind it. */
+.medium-zoom-overlay,
+.medium-zoom-image--opened {
+  z-index: 9999 !important;
+}
+
 /* Minimize button — replaces ::after, now functional */
 .image-collapse-btn {
   position: absolute;


### PR DESCRIPTION
  ## Summary
  - Add `docusaurus-plugin-image-zoom` (wraps medium-zoom) so doc images zoom on click
  - Restrict the zoom selector to the docs main container so it doesn't grab navbar/footer images
  - Bump overlay/zoomed-image z-index in `src/css/custom.css` so the zoom sits above the sticky navbar

  ## Test plan
  - [ ] Click an image inside a docs page — zooms into a full-screen overlay
  - [ ] Overlay sits above the navbar (not behind it)
  - [ ] Click outside / press Esc to dismiss
  - [ ] Verify in both light and dark themes
  - [ ] Navbar logo / footer images are not click-zoomable