### PR TITLE
Fix dev server child process cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch-templates": "node scripts/build-html.js --watch",
     "prebuild": "node scripts/build-html.js && bash scripts/import-external-docs.sh",
     "docusaurus": "docusaurus",
-    "start": "node scripts/build-html.js --watch & docusaurus start",
+    "start": "bash scripts/start-dev.sh",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# Start the Docusaurus dev server plus the helper watchers used during local
-# external-docs development. Keeping this in a script instead of a long
-# package.json one-liner lets us clean up child processes reliably on Ctrl+C.
+# Start the normal Docusaurus dev server plus the static HTML template watcher.
+# This replaces the old package.json `cmd & docusaurus start` one-liner so all
+# child processes are cleaned up reliably when Docusaurus exits or Ctrl+C is
+# pressed.
 
 PIDS=()
 
@@ -21,13 +22,7 @@ handle_signal() {
 trap cleanup EXIT
 trap handle_signal INT TERM
 
-node scripts/build-html.js
-bash scripts/import-external-docs.sh
-
 node scripts/build-html.js --watch &
-PIDS+=("$!")
-
-bash scripts/import-external-docs.sh --watch &
 PIDS+=("$!")
 
 docusaurus start &
@@ -35,5 +30,5 @@ PIDS+=("$!")
 DOCUSAURUS_PID="$!"
 
 # Wait on Docusaurus as the primary process. When it exits, the EXIT trap stops
-# both background watchers too.
+# the template watcher too.
 wait "$DOCUSAURUS_PID"


### PR DESCRIPTION
## Summary
- replace the raw `cmd & docusaurus start` npm script with `scripts/start-dev.sh`
- track and clean up dev-server child processes explicitly
- tighten `start-local-docs.sh` signal handling so local-docs watchers are also cleaned up

## Testing
- `bash -n scripts/start-dev.sh scripts/start-local-docs.sh`
- `PORT=3999 BROWSER=none npm start` (server started and served `/`)
- `PORT=3998 BROWSER=none EXTERNAL_DOCS_LOCAL_PROJECT_QUIVER=/Users/thomas/.openclaw/workspace/test-runs/project-quiver npm run start:local-docs` (server started with local Quiver docs and served `/`)
- `npm run build`

Note: Docusaurus attempted to open Brave via AppleScript locally and that AppleScript failed, but the dev server stayed up and served HTTP. That appears unrelated to this process-lifecycle bug.