### PR TITLE
Prepare bounty board for generated data

### DIFF
--- a/docs-bounty/index.mdx
+++ b/docs-bounty/index.mdx
@@ -5,6 +5,7 @@ hide_table_of_contents: true
 ---
 
 import BountyTable from '@site/src/components/BountyTable';
+import bounties from '@site/src/data/bounties.generated.json';
 
 # Bounty Board
 
@@ -16,178 +17,22 @@ Complete a bounty to earn USDC and $ARROW tokens. New to the process? See [How t
 
 Hardware and mechanical engineering tasks for Project Quiver (PT3). Covers CAD design, structural analysis, propulsion testing, and related documentation.
 
-<BountyTable hideClaimedToggle rows={[
-  {
-    title: 'Quiver Payload Attachment Design',
-    description: 'Design a modular payload attachment system for the PT3 airframe. The solution should allow quick-swap of payloads up to 500g, integrate with existing mounting points, and be manufacturable with standard tools. Deliverable: CAD files + assembly guide.',
-    status: 'OPEN',
-    usdc: '$500',
-    arrow: '2,000',
-    posted: 'Apr 28, 2026',
-    expires: 'Jun 15, 2026',
-    skills: ['CAD', 'Research'],
-    image: '/img/quiver-3d.png',
-    outline: 'https://github.com/Arrow-air/project-quiver',
-    apply: 'https://github.com/Arrow-air/project-quiver',
-  },
-  {
-    title: 'Landing Gear Iteration — PT3',
-    description: 'Redesign the PT3 landing gear to improve ground clearance for payload operations and reduce weight by at least 15% compared to the current design. Must survive a 1.5m drop test. Deliverable: updated CAD + drop test video.',
-    status: 'OPEN',
-    usdc: '$600',
-    arrow: '2,500',
-    posted: 'May 5, 2026',
-    expires: 'Jun 25, 2026',
-    skills: ['CAD', 'Testing'],
-    image: '/img/quiver-01.jpg',
-    outline: 'https://github.com/Arrow-air/project-quiver',
-    apply: 'https://github.com/Arrow-air/project-quiver',
-  },
-  {
-    title: 'Flight Controller Tuning Guide',
-    description: 'Write a step-by-step tuning guide for the PT3 flight controller covering initial setup, PID tuning methodology, and common failure modes. Must be reproducible by a new contributor with no prior FC experience.',
-    status: 'CLAIMED',
-    usdc: '$300',
-    arrow: '1,000',
-    posted: 'Apr 10, 2026',
-    expires: 'May 30, 2026',
-    skills: ['Writing', 'Testing'],
-    image: '/img/pixel-quiver.png',
-    outline: 'https://github.com/Arrow-air/project-quiver',
-  },
-]} />
+<BountyTable hideClaimedToggle rows={bounties.engineering} />
 
 ## Software
 
 Structural and aerodynamic engineering work for Project Spearhead. Includes FEA, CFD simulations, design reviews, and avionics integration.
 
-<BountyTable hideClaimedToggle rows={[
-  {
-    title: 'Spearhead Airframe Stress Analysis',
-    description: 'Perform structural analysis on the Spearhead airframe under 3.8g positive and 1.5g negative load cases. Identify critical members and propose reinforcement if margins are below 1.5. Deliverable: analysis report + updated CAD.',
-    status: 'OPEN',
-    usdc: '$750',
-    arrow: '3,000',
-    posted: 'Apr 20, 2026',
-    expires: 'Jun 10, 2026',
-    skills: ['FEA', 'CAD'],
-    image: '/img/spearhead.png',
-    outline: 'https://github.com/Arrow-air/project-spearhead',
-    apply: 'https://github.com/Arrow-air/project-spearhead',
-  },
-  {
-    title: 'Wing Profile CFD Simulation',
-    description: 'Run CFD simulations on the Spearhead wing profile at cruise AoA range (−2° to +8°) and generate Cl/Cd polars. Compare at least 2 NACA profiles. Deliverable: simulation files + polar data + recommendation.',
-    status: 'OPEN',
-    usdc: '$900',
-    arrow: '4,000',
-    posted: 'May 1, 2026',
-    expires: 'Jun 20, 2026',
-    skills: ['CFD', 'Research'],
-    image: '/img/spearhead-card.png',
-    outline: 'https://github.com/Arrow-air/project-spearhead',
-    apply: 'https://github.com/Arrow-air/project-spearhead',
-  },
-  {
-    title: 'Spearhead Weight Budget Analysis',
-    description: 'Compile a full weight budget for the Spearhead prototype including all subsystems. Identify top contributors and propose design changes to meet the target MTOW.',
-    status: 'CLAIMED',
-    usdc: '$400',
-    arrow: '1,500',
-    posted: 'Apr 5, 2026',
-    expires: 'May 25, 2026',
-    skills: ['Research', 'Writing'],
-    image: '/img/spearhead-card.png',
-    outline: 'https://github.com/Arrow-air/project-spearhead',
-  },
-]} />
+<BountyTable hideClaimedToggle rows={bounties.software} />
 
 ## Growth & Media
 
 Cross-project software tools, developer documentation, and technical resources spanning both Quiver and Spearhead. Good for software engineers and technical writers.
 
-<BountyTable hideClaimedToggle rows={[
-  {
-    title: 'Cross-Project Telemetry Dashboard',
-    description: 'Build a dashboard that aggregates live and logged telemetry from Quiver and Spearhead flight sessions. Must support MAVLink and display altitude, battery, and GPS track. Deliverable: open-source repo + demo video.',
-    status: 'OPEN',
-    usdc: '$600',
-    arrow: '2,500',
-    posted: 'May 3, 2026',
-    expires: 'Jun 20, 2026',
-    skills: ['Python', 'TypeScript'],
-    image: '/img/software-engineering@2x.png',
-    outline: 'https://github.com/Arrow-air',
-    apply: 'https://github.com/Arrow-air',
-  },
-  {
-    title: 'Engineering Wiki — Getting Started Guide',
-    description: 'Write a getting-started guide for new engineering contributors covering: repo structure, tooling setup (CAD, simulation, firmware), contribution workflow, and where to ask questions. Target audience: mechanical or software engineer with no prior Arrow experience.',
-    status: 'OPEN',
-    usdc: '$250',
-    arrow: '800',
-    posted: 'Apr 25, 2026',
-    expires: 'Jun 12, 2026',
-    skills: ['Writing'],
-    image: '/img/software-engineering@2x.png',
-    outline: 'https://github.com/Arrow-air',
-    apply: 'https://github.com/Arrow-air',
-  },
-  {
-    title: 'CI/CD Pipeline Documentation',
-    description: 'Document the existing CI/CD pipelines across Arrow repos — what runs on each trigger, how to interpret failures, and how to add new checks. Includes firmware, simulation, and website pipelines.',
-    status: 'CLAIMED',
-    usdc: '$300',
-    arrow: '1,000',
-    posted: 'Apr 12, 2026',
-    expires: 'May 28, 2026',
-    skills: ['DevOps', 'Writing'],
-    image: '/img/software-engineering@2x.png',
-    outline: 'https://github.com/Arrow-air',
-  },
-]} />
+<BountyTable hideClaimedToggle rows={bounties.growthMedia} />
 
 ## General DAO
 
 Design, content, and community-focused work supporting Arrow's broader mission. Includes UI wireframes, onboarding guides, social media, and translation — open to non-engineers.
 
-<BountyTable hideClaimedToggle rows={[
-  {
-    title: 'Ground Station UI Wireframes',
-    description: 'Design wireframes for a ground station UI supporting live flight monitoring of Quiver and Spearhead. Cover: pre-flight checklist, live telemetry view, mission planning map, and post-flight log review. Deliverable: Figma or equivalent file.',
-    status: 'OPEN',
-    usdc: '$450',
-    arrow: '1,800',
-    posted: 'May 8, 2026',
-    expires: 'Jun 30, 2026',
-    skills: ['Design'],
-    image: '/img/sky-grey-01.png',
-    outline: 'https://github.com/Arrow-air/project-quiver',
-    apply: 'https://github.com/Arrow-air/project-quiver',
-  },
-  {
-    title: 'Translate Docs to Spanish',
-    description: 'Translate the Arrow contributing docs and project overview into Spanish. Target audience: Spanish-speaking engineers and makers in Latin America and Spain who want to contribute but prefer reading in their native language.',
-    status: 'OPEN',
-    usdc: '$300',
-    arrow: '1,000',
-    posted: 'Apr 22, 2026',
-    expires: 'Jun 25, 2026',
-    skills: ['Translation', 'Writing'],
-    image: '/img/global@2x.png',
-    outline: 'https://github.com/Arrow-air/project-quiver',
-    apply: 'https://github.com/Arrow-air/project-quiver',
-  },
-  {
-    title: 'Project Quiver Build Video',
-    description: 'Create a full build video documenting the PT3 assembly process from raw components to maiden flight.',
-    status: 'CLAIMED',
-    usdc: '$500',
-    arrow: '2,000',
-    posted: 'Apr 1, 2026',
-    expires: 'May 20, 2026',
-    skills: ['Video'],
-    image: '/img/quiver-01.jpg',
-    outline: 'https://github.com/Arrow-air/project-quiver',
-  },
-]} />
+<BountyTable hideClaimedToggle rows={bounties.generalDao} />

--- a/src/components/BountyTable.tsx
+++ b/src/components/BountyTable.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-type BountyStatus = 'OPEN' | 'CLAIMED' | 'CLOSED';
+type BountyStatus = 'OPEN' | 'CLAIMED' | 'EXPIRED' | 'CLOSED';
 
 export type SkillTag =
   | 'CAD'
@@ -10,11 +10,15 @@ export type SkillTag =
   | 'TypeScript'
   | 'Rust'
   | 'Electronics'
+  | 'Software'
   | 'DevOps'
   | 'Writing'
+  | 'Documentation'
   | 'Translation'
   | 'Design'
+  | 'Media'
   | 'Video'
+  | 'Governance'
   | 'Research'
   | 'Testing';
 
@@ -22,12 +26,18 @@ export type BountyRow = {
   title: string;
   description: string;
   status: BountyStatus;
-  usdc: string;
-  arrow: string;
-  expires: string;
+  usdc?: string;
+  arrow?: string;
+  expires?: string;
+  expectedWindow?: string;
   skills?: SkillTag[];
   posted?: string;
+  issueUrl?: string;
+  applyUrl?: string;
+  detailUrl?: string;
+  /** @deprecated Use issueUrl instead. */
   outline?: string;
+  /** @deprecated Use applyUrl instead. */
   apply?: string;
   image?: string;
 };
@@ -46,6 +56,24 @@ function formatExpires(input: string): string {
   const d = new Date(input);
   if (Number.isNaN(d.getTime())) return input;
   return d.toLocaleDateString('en-US', { month: 'short', day: '2-digit', year: 'numeric' });
+}
+
+function getReadMoreUrl(row: BountyRow): string | undefined {
+  return row.detailUrl ?? row.issueUrl ?? row.outline;
+}
+
+function getIssueUrl(row: BountyRow): string | undefined {
+  return row.issueUrl ?? row.outline;
+}
+
+function getApplyUrl(row: BountyRow): string | undefined {
+  return row.applyUrl ?? row.apply;
+}
+
+function getTimingLabel(row: BountyRow): string | undefined {
+  if (row.expires) return `Expires ${formatExpires(row.expires)}`;
+  if (row.expectedWindow) return row.expectedWindow;
+  return undefined;
 }
 
 function PhotoPlaceholder({ size = 72 }: { size?: number }) {
@@ -133,7 +161,9 @@ export default function BountyTable({ rows, hideClaimedToggle = false }: { rows:
                           const MAX = 130;
                           const isLong = row.description.length > MAX;
                           const excerpt = isLong ? row.description.slice(0, MAX).trimEnd() : row.description;
-                          return <>{excerpt}{isLong && <>{' '}...<a href={row.outline} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'underline', color: 'inherit' }}>read more</a></>}{' '}<span style={{ fontWeight: 500, color: 'var(--docs-text-primary, #374151)' }}>| Expires {formatExpires(row.expires)}</span></>;
+                          const readMoreUrl = getReadMoreUrl(row);
+                          const timing = getTimingLabel(row);
+                          return <>{excerpt}{isLong && readMoreUrl && <>{' '}...<a href={readMoreUrl} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'underline', color: 'inherit' }}>read more</a></>}{timing && <> <span style={{ fontWeight: 500, color: 'var(--docs-text-primary, #374151)' }}>| {timing}</span></>}</>;
                         })()}
                       </span>
                     </span>
@@ -141,22 +171,27 @@ export default function BountyTable({ rows, hideClaimedToggle = false }: { rows:
                 </td>
                 <td>
                   <span style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-                    <span className="bt-pill-usdc" style={{
-                      ...PILL_BASE,
-                      padding: '4px 6px',
-                      border: '1px solid rgba(8,67,191,0.4)',
-                      color: '#0843BF',
-                      background: 'rgba(8,67,191,0.07)',
-                      cursor: 'default',
-                    }}>{row.usdc} USDC</span>
-                    <span className="bt-pill-arrow" style={{
-                      ...PILL_BASE,
-                      padding: '4px 6px',
-                      border: '1px solid rgba(8,67,191,0.4)',
-                      color: '#0843BF',
-                      background: 'rgba(8,67,191,0.07)',
-                      cursor: 'default',
-                    }}>{row.arrow} $ARROW</span>
+                    {row.usdc && (
+                      <span className="bt-pill-usdc" style={{
+                        ...PILL_BASE,
+                        padding: '4px 6px',
+                        border: '1px solid rgba(8,67,191,0.4)',
+                        color: '#0843BF',
+                        background: 'rgba(8,67,191,0.07)',
+                        cursor: 'default',
+                      }}>{row.usdc} USDC</span>
+                    )}
+                    {row.arrow && (
+                      <span className="bt-pill-arrow" style={{
+                        ...PILL_BASE,
+                        padding: '4px 6px',
+                        border: '1px solid rgba(8,67,191,0.4)',
+                        color: '#0843BF',
+                        background: 'rgba(8,67,191,0.07)',
+                        cursor: 'default',
+                      }}>{row.arrow} $ARROW</span>
+                    )}
+                    {!row.usdc && !row.arrow && '—'}
                   </span>
                 </td>
                 <td>
@@ -171,9 +206,29 @@ export default function BountyTable({ rows, hideClaimedToggle = false }: { rows:
                         letterSpacing: '-0.28px',
                         cursor: 'default',
                       }}>Claimed</span>
-                    ) : row.apply && (
+                    ) : row.status === 'EXPIRED' ? (
+                      <span className="bt-pill-expired" style={{
+                        ...PILL_BASE,
+                        padding: '4px 6px',
+                        border: '1px solid rgba(107,114,128,0.45)',
+                        color: 'var(--docs-text-secondary, #6b7280)',
+                        background: 'rgba(107,114,128,0.12)',
+                        letterSpacing: '-0.28px',
+                        cursor: 'default',
+                      }}>Expired</span>
+                    ) : row.status === 'CLOSED' ? (
+                      <span className="bt-pill-closed" style={{
+                        ...PILL_BASE,
+                        padding: '4px 6px',
+                        border: '1px solid rgba(107,114,128,0.45)',
+                        color: 'var(--docs-text-secondary, #6b7280)',
+                        background: 'rgba(107,114,128,0.07)',
+                        letterSpacing: '-0.28px',
+                        cursor: 'default',
+                      }}>Closed</span>
+                    ) : getApplyUrl(row) && (
                       <a
-                        href={row.apply}
+                        href={getApplyUrl(row)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="bt-pill-apply"
@@ -188,9 +243,9 @@ export default function BountyTable({ rows, hideClaimedToggle = false }: { rows:
                         }}
                       >Apply</a>
                     )}
-                    {row.outline && (
+                    {getIssueUrl(row) && (
                       <a
-                        href={row.outline}
+                        href={getIssueUrl(row)}
                         target="_blank"
                         rel="noopener noreferrer"
                         style={{
@@ -204,7 +259,7 @@ export default function BountyTable({ rows, hideClaimedToggle = false }: { rows:
                         }}
                       >GitHub</a>
                     )}
-                    {!row.outline && !row.apply && '—'}
+                    {!getIssueUrl(row) && !getApplyUrl(row) && '—'}
                   </span>
                 </td>
               </tr>

--- a/src/data/bounties.generated.json
+++ b/src/data/bounties.generated.json
@@ -1,0 +1,195 @@
+{
+  "engineering": [
+    {
+      "title": "Quiver Payload Attachment Design",
+      "description": "Design a modular payload attachment system for the PT3 airframe. The solution should allow quick-swap of payloads up to 500g, integrate with existing mounting points, and be manufacturable with standard tools. Deliverable: CAD files + assembly guide.",
+      "status": "OPEN",
+      "usdc": "$500",
+      "arrow": "2,000",
+      "posted": "Apr 28, 2026",
+      "expires": "Jun 15, 2026",
+      "skills": [
+        "CAD",
+        "Research"
+      ],
+      "image": "/img/quiver-3d.png",
+      "issueUrl": "https://github.com/Arrow-air/project-quiver",
+      "applyUrl": "https://github.com/Arrow-air/project-quiver"
+    },
+    {
+      "title": "Landing Gear Iteration — PT3",
+      "description": "Redesign the PT3 landing gear to improve ground clearance for payload operations and reduce weight by at least 15% compared to the current design. Must survive a 1.5m drop test. Deliverable: updated CAD + drop test video.",
+      "status": "OPEN",
+      "usdc": "$600",
+      "arrow": "2,500",
+      "posted": "May 5, 2026",
+      "expires": "Jun 25, 2026",
+      "skills": [
+        "CAD",
+        "Testing"
+      ],
+      "image": "/img/quiver-01.jpg",
+      "issueUrl": "https://github.com/Arrow-air/project-quiver",
+      "applyUrl": "https://github.com/Arrow-air/project-quiver"
+    },
+    {
+      "title": "Flight Controller Tuning Guide",
+      "description": "Write a step-by-step tuning guide for the PT3 flight controller covering initial setup, PID tuning methodology, and common failure modes. Must be reproducible by a new contributor with no prior FC experience.",
+      "status": "CLAIMED",
+      "usdc": "$300",
+      "arrow": "1,000",
+      "posted": "Apr 10, 2026",
+      "expires": "May 30, 2026",
+      "skills": [
+        "Writing",
+        "Testing"
+      ],
+      "image": "/img/pixel-quiver.png",
+      "issueUrl": "https://github.com/Arrow-air/project-quiver"
+    }
+  ],
+  "software": [
+    {
+      "title": "Spearhead Airframe Stress Analysis",
+      "description": "Perform structural analysis on the Spearhead airframe under 3.8g positive and 1.5g negative load cases. Identify critical members and propose reinforcement if margins are below 1.5. Deliverable: analysis report + updated CAD.",
+      "status": "OPEN",
+      "usdc": "$750",
+      "arrow": "3,000",
+      "posted": "Apr 20, 2026",
+      "expires": "Jun 10, 2026",
+      "skills": [
+        "FEA",
+        "CAD"
+      ],
+      "image": "/img/spearhead.png",
+      "issueUrl": "https://github.com/Arrow-air/project-spearhead",
+      "applyUrl": "https://github.com/Arrow-air/project-spearhead"
+    },
+    {
+      "title": "Wing Profile CFD Simulation",
+      "description": "Run CFD simulations on the Spearhead wing profile at cruise AoA range (−2° to +8°) and generate Cl/Cd polars. Compare at least 2 NACA profiles. Deliverable: simulation files + polar data + recommendation.",
+      "status": "OPEN",
+      "usdc": "$900",
+      "arrow": "4,000",
+      "posted": "May 1, 2026",
+      "expires": "Jun 20, 2026",
+      "skills": [
+        "CFD",
+        "Research"
+      ],
+      "image": "/img/spearhead-card.png",
+      "issueUrl": "https://github.com/Arrow-air/project-spearhead",
+      "applyUrl": "https://github.com/Arrow-air/project-spearhead"
+    },
+    {
+      "title": "Spearhead Weight Budget Analysis",
+      "description": "Compile a full weight budget for the Spearhead prototype including all subsystems. Identify top contributors and propose design changes to meet the target MTOW.",
+      "status": "CLAIMED",
+      "usdc": "$400",
+      "arrow": "1,500",
+      "posted": "Apr 5, 2026",
+      "expires": "May 25, 2026",
+      "skills": [
+        "Research",
+        "Writing"
+      ],
+      "image": "/img/spearhead-card.png",
+      "issueUrl": "https://github.com/Arrow-air/project-spearhead"
+    }
+  ],
+  "growthMedia": [
+    {
+      "title": "Cross-Project Telemetry Dashboard",
+      "description": "Build a dashboard that aggregates live and logged telemetry from Quiver and Spearhead flight sessions. Must support MAVLink and display altitude, battery, and GPS track. Deliverable: open-source repo + demo video.",
+      "status": "OPEN",
+      "usdc": "$600",
+      "arrow": "2,500",
+      "posted": "May 3, 2026",
+      "expires": "Jun 20, 2026",
+      "skills": [
+        "Software",
+        "Testing"
+      ],
+      "image": "/img/software-engineering@2x.png",
+      "issueUrl": "https://github.com/Arrow-air",
+      "applyUrl": "https://github.com/Arrow-air"
+    },
+    {
+      "title": "Engineering Wiki — Getting Started Guide",
+      "description": "Write a getting-started guide for new engineering contributors covering: repo structure, tooling setup (CAD, simulation, firmware), contribution workflow, and where to ask questions. Target audience: mechanical or software engineer with no prior Arrow experience.",
+      "status": "OPEN",
+      "usdc": "$250",
+      "arrow": "800",
+      "posted": "Apr 25, 2026",
+      "expires": "Jun 12, 2026",
+      "skills": [
+        "Documentation"
+      ],
+      "image": "/img/software-engineering@2x.png",
+      "issueUrl": "https://github.com/Arrow-air",
+      "applyUrl": "https://github.com/Arrow-air"
+    },
+    {
+      "title": "CI/CD Pipeline Documentation",
+      "description": "Document the existing CI/CD pipelines across Arrow repos — what runs on each trigger, how to interpret failures, and how to add new checks. Includes firmware, simulation, and website pipelines.",
+      "status": "CLAIMED",
+      "usdc": "$300",
+      "arrow": "1,000",
+      "posted": "Apr 12, 2026",
+      "expires": "May 28, 2026",
+      "skills": [
+        "Software",
+        "Documentation"
+      ],
+      "image": "/img/software-engineering@2x.png",
+      "issueUrl": "https://github.com/Arrow-air"
+    }
+  ],
+  "generalDao": [
+    {
+      "title": "Ground Station UI Wireframes",
+      "description": "Design wireframes for a ground station UI supporting live flight monitoring of Quiver and Spearhead. Cover: pre-flight checklist, live telemetry view, mission planning map, and post-flight log review. Deliverable: Figma or equivalent file.",
+      "status": "OPEN",
+      "usdc": "$450",
+      "arrow": "1,800",
+      "posted": "May 8, 2026",
+      "expires": "Jun 30, 2026",
+      "skills": [
+        "Design"
+      ],
+      "image": "/img/sky-grey-01.png",
+      "issueUrl": "https://github.com/Arrow-air/project-quiver",
+      "applyUrl": "https://github.com/Arrow-air/project-quiver"
+    },
+    {
+      "title": "Translate Docs to Spanish",
+      "description": "Translate the Arrow contributing docs and project overview into Spanish. Target audience: Spanish-speaking engineers and makers in Latin America and Spain who want to contribute but prefer reading in their native language.",
+      "status": "OPEN",
+      "usdc": "$300",
+      "arrow": "1,000",
+      "posted": "Apr 22, 2026",
+      "expires": "Jun 25, 2026",
+      "skills": [
+        "Documentation",
+        "Writing"
+      ],
+      "image": "/img/global@2x.png",
+      "issueUrl": "https://github.com/Arrow-air/project-quiver",
+      "applyUrl": "https://github.com/Arrow-air/project-quiver"
+    },
+    {
+      "title": "Project Quiver Build Video",
+      "description": "Create a full build video documenting the PT3 assembly process from raw components to maiden flight.",
+      "status": "CLAIMED",
+      "usdc": "$500",
+      "arrow": "2,000",
+      "posted": "Apr 1, 2026",
+      "expires": "May 20, 2026",
+      "skills": [
+        "Media"
+      ],
+      "image": "/img/quiver-01.jpg",
+      "issueUrl": "https://github.com/Arrow-air/project-quiver"
+    }
+  ]
+}

--- a/src/data/bounties.generated.json
+++ b/src/data/bounties.generated.json
@@ -116,9 +116,8 @@
     },
     {
       "title": "Engineering Wiki — Getting Started Guide",
-      "description": "Write a getting-started guide for new engineering contributors covering: repo structure, tooling setup (CAD, simulation, firmware), contribution workflow, and where to ask questions. Target audience: mechanical or software engineer with no prior Arrow experience.",
+      "description": "Write an ARROW-only demo getting-started guide for new engineering contributors covering: repo structure, tooling setup (CAD, simulation, firmware), contribution workflow, and where to ask questions. Target audience: mechanical or software engineer with no prior Arrow experience.",
       "status": "OPEN",
-      "usdc": "$250",
       "arrow": "800",
       "posted": "Apr 25, 2026",
       "expires": "Jun 12, 2026",
@@ -131,10 +130,9 @@
     },
     {
       "title": "CI/CD Pipeline Documentation",
-      "description": "Document the existing CI/CD pipelines across Arrow repos — what runs on each trigger, how to interpret failures, and how to add new checks. Includes firmware, simulation, and website pipelines.",
+      "description": "Document the existing CI/CD pipelines as a USDC-only demo across Arrow repos — what runs on each trigger, how to interpret failures, and how to add new checks. Includes firmware, simulation, and website pipelines.",
       "status": "CLAIMED",
       "usdc": "$300",
-      "arrow": "1,000",
       "posted": "Apr 12, 2026",
       "expires": "May 28, 2026",
       "skills": [
@@ -164,11 +162,11 @@
     {
       "title": "Translate Docs to Spanish",
       "description": "Translate the Arrow contributing docs and project overview into Spanish. Target audience: Spanish-speaking engineers and makers in Latin America and Spain who want to contribute but prefer reading in their native language.",
-      "status": "OPEN",
+      "status": "EXPIRED",
       "usdc": "$300",
       "arrow": "1,000",
       "posted": "Apr 22, 2026",
-      "expires": "Jun 25, 2026",
+      "expires": "2026-05-01",
       "skills": [
         "Documentation",
         "Writing"

--- a/src/data/bounties.schema.json
+++ b/src/data/bounties.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://arrowair.com/schemas/bounties.generated.schema.json",
+  "title": "Arrow generated bounty board data",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["engineering", "software", "growthMedia", "generalDao"],
+  "properties": {
+    "engineering": { "$ref": "#/$defs/bountyRows" },
+    "software": { "$ref": "#/$defs/bountyRows" },
+    "growthMedia": { "$ref": "#/$defs/bountyRows" },
+    "generalDao": { "$ref": "#/$defs/bountyRows" }
+  },
+  "$defs": {
+    "bountyRows": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/bountyRow" }
+    },
+    "bountyRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "description", "status"],
+      "properties": {
+        "title": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["OPEN", "CLAIMED", "EXPIRED", "CLOSED"] },
+        "usdc": { "type": "string", "minLength": 1 },
+        "arrow": { "type": "string", "minLength": 1 },
+        "expires": { "type": "string", "minLength": 1 },
+        "expectedWindow": { "type": "string", "minLength": 1 },
+        "skills": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "Engineering",
+              "CAD",
+              "Electronics",
+              "Software",
+              "Documentation",
+              "Design",
+              "Media",
+              "Research",
+              "Testing",
+              "Governance",
+              "FEA",
+              "CFD",
+              "Python",
+              "TypeScript",
+              "Rust",
+              "DevOps",
+              "Writing",
+              "Translation",
+              "Video"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "posted": { "type": "string", "minLength": 1 },
+        "issueUrl": { "type": "string", "format": "uri" },
+        "applyUrl": { "type": "string", "format": "uri" },
+        "detailUrl": { "type": "string", "minLength": 1 },
+        "image": { "type": "string", "minLength": 1 }
+      },
+      "anyOf": [
+        { "required": ["usdc"] },
+        { "required": ["arrow"] }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Move hardcoded bounty-board rows into a generated JSON data file.
- Add a JSON schema for generated bounty data.
- Make bounty reward fields optional so bounties can be USDC-only, ARROW-only, or both.
- Add support for `EXPIRED` / `CLOSED` display states and explicit `issueUrl`, `applyUrl`, and `detailUrl` fields.
- Keep the existing description truncation and `...read more` behavior.

## Notes

This is PR 1 of the bounty issue → bounty board pipeline. It intentionally does **not** add the GitHub issue form or sync automation yet.

Later PRs can replace `src/data/bounties.generated.json` via script without changing the UI again.

## Verification

- `npm run typecheck`
- `npm run build`
