### PR TITLE
Remove bounty issue title prefix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -1,6 +1,5 @@
 name: Bounty
 description: Create a bounty-backed work item
-title: "[Bounty]: "
 labels: ["bounty"]
 body:
   - type: markdown


### PR DESCRIPTION
## Summary

- Remove the prefilled `[Bounty]:` title prefix from the Bounty issue form.

## Notes

The `bounty` label is the machine-readable signal for the sync pipeline. The sync script already strips `[Bounty]:` if older issues have it, so removing the prefix does not break existing issues.

## Verification

- `npm run typecheck`
- `npm run build`
